### PR TITLE
feat: split up capability structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -835,7 +835,16 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
 dependencies = [
- "derive_more-impl",
+ "derive_more-impl 1.0.0",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl 2.0.1",
 ]
 
 [[package]]
@@ -848,6 +857,17 @@ dependencies = [
  "quote",
  "syn 2.0.98",
  "unicode-xid",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1973,7 +1993,7 @@ dependencies = [
  "crypto_box",
  "data-encoding",
  "der",
- "derive_more",
+ "derive_more 1.0.0",
  "ed25519-dalek",
  "futures-util",
  "hickory-resolver",
@@ -2001,7 +2021,7 @@ dependencies = [
  "rustls-webpki",
  "serde",
  "smallvec",
- "strum",
+ "strum 0.26.3",
  "stun-rs",
  "thiserror 2.0.11",
  "time",
@@ -2024,7 +2044,7 @@ checksum = "02bf2374c0f1d01cde6e60de7505e42a604acda1a1bb3f7be19806e466055517"
 dependencies = [
  "curve25519-dalek",
  "data-encoding",
- "derive_more",
+ "derive_more 1.0.0",
  "ed25519-dalek",
  "postcard",
  "rand_core 0.6.4",
@@ -2058,7 +2078,7 @@ dependencies = [
  "bytes",
  "chrono",
  "data-encoding",
- "derive_more",
+ "derive_more 1.0.0",
  "futures-buffered",
  "futures-lite",
  "futures-util",
@@ -2087,7 +2107,7 @@ dependencies = [
  "serde-error",
  "smallvec",
  "ssh-key",
- "strum",
+ "strum 0.26.3",
  "tempfile",
  "thiserror 2.0.11",
  "tokio",
@@ -2135,6 +2155,7 @@ name = "iroh-n0des"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "derive_more 2.0.1",
  "ed25519-dalek",
  "iroh",
  "iroh-blobs",
@@ -2144,6 +2165,7 @@ dependencies = [
  "rcan",
  "serde",
  "ssh-key",
+ "strum 0.27.1",
  "tokio",
  "tokio-serde",
  "tokio-util",
@@ -2160,7 +2182,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cfg_aliases",
- "derive_more",
+ "derive_more 1.0.0",
  "hickory-resolver",
  "iroh-base",
  "iroh-metrics",
@@ -2247,7 +2269,7 @@ dependencies = [
  "clap",
  "dashmap",
  "data-encoding",
- "derive_more",
+ "derive_more 1.0.0",
  "governor",
  "hickory-proto",
  "hickory-resolver",
@@ -2276,7 +2298,7 @@ dependencies = [
  "rustls-pemfile",
  "rustls-webpki",
  "serde",
- "strum",
+ "strum 0.26.3",
  "stun-rs",
  "thiserror 2.0.11",
  "time",
@@ -2528,7 +2550,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "399e11dc3b0e8d9d65b27170d22f5d779d52d9bed888db70d7e0c2c7ce3dfc52"
 dependencies = [
  "cfg_aliases",
- "derive_more",
+ "derive_more 1.0.0",
  "futures-buffered",
  "futures-lite",
  "futures-util",
@@ -2667,7 +2689,7 @@ dependencies = [
  "anyhow",
  "atomic-waker",
  "bytes",
- "derive_more",
+ "derive_more 1.0.0",
  "futures-lite",
  "futures-sink",
  "futures-util",
@@ -2700,7 +2722,7 @@ dependencies = [
  "atomic-waker",
  "bytes",
  "cfg_aliases",
- "derive_more",
+ "derive_more 1.0.0",
  "iroh-quinn-udp",
  "js-sys",
  "libc",
@@ -3213,7 +3235,7 @@ checksum = "b715da165f399be093fecb2ca774b00713a3b32f6b27e0752fbf255e3be622af"
 dependencies = [
  "base64",
  "bytes",
- "derive_more",
+ "derive_more 1.0.0",
  "futures-lite",
  "futures-util",
  "igd-next",
@@ -3614,7 +3636,7 @@ source = "git+https://github.com/n0-computer/rcan?branch=main#ee64cf69d7626b9d54
 dependencies = [
  "anyhow",
  "blake3",
- "derive_more",
+ "derive_more 1.0.0",
  "ed25519-dalek",
  "hex",
  "postcard",
@@ -4447,7 +4469,16 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+dependencies = [
+ "strum_macros 0.27.1",
 ]
 
 [[package]]
@@ -4455,6 +4486,19 @@ name = "strum_macros"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3610,7 +3610,7 @@ dependencies = [
 [[package]]
 name = "rcan"
 version = "0.1.0"
-source = "git+https://github.com/dignifiedquire/rcan?branch=main#fea48cf8290a8e6d77518bb1cd4b2c89388afa1f"
+source = "git+https://github.com/Frando/rcan?branch=refactor%2Fdelegate-permits#cdea3d480596be1eefbf0534fcf19a6c96faaa7a"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3610,7 +3610,7 @@ dependencies = [
 [[package]]
 name = "rcan"
 version = "0.1.0"
-source = "git+https://github.com/Frando/rcan?branch=refactor%2Fdelegate-permits#cdea3d480596be1eefbf0534fcf19a6c96faaa7a"
+source = "git+https://github.com/n0-computer/rcan?branch=main#ee64cf69d7626b9d54431796d0d1df0af2a69669"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,6 @@ rand = "0.8"
 
 [features]
 bin = ["iroh-blobs/rpc"]
+
+[patch."https://github.com/dignifiedquire/rcan"]
+rcan = { git = "https://github.com/Frando/rcan", branch = "refactor/delegate-permits" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ tokio = "1.43.0"
 iroh-metrics = "0.32"
 tracing = "0.1.41"
 rand = "0.8"
+derive_more = { version = "2.0.1", features = ["from"] }
+strum = { version = "0.27.1", features = ["derive"] }
 
 [features]
 bin = ["iroh-blobs/rpc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1.0.217", features = ["derive"] }
 tokio-serde = { version = "0.9.0", features = ["bincode"] }
 tokio-util = { version = "0.7.13", features = ["codec"] }
 uuid = { version = "1.12.1", features = ["v4", "serde"] }
-rcan = { git = "https://github.com/dignifiedquire/rcan", branch = "main" }
+rcan = { git = "https://github.com/n0-computer/rcan", branch = "main" }
 ed25519-dalek = "2.1.1"
 ssh-key = { version = "0.6.7", features = ["ed25519"] }
 tokio = "1.43.0"
@@ -29,6 +29,3 @@ rand = "0.8"
 
 [features]
 bin = ["iroh-blobs/rpc"]
-
-[patch."https://github.com/dignifiedquire/rcan"]
-rcan = { git = "https://github.com/Frando/rcan", branch = "refactor/delegate-permits" }

--- a/src/caps.rs
+++ b/src/caps.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{collections::BTreeSet, time::Duration};
 
 use anyhow::{Context, Result};
 use ed25519_dalek::{SigningKey, VerifyingKey};
@@ -7,28 +7,128 @@ use rcan::{Capability, Expires, Rcan};
 use serde::{Deserialize, Serialize};
 use ssh_key::PrivateKey as SshPrivateKey;
 
-#[derive(Ord, Eq, PartialOrd, PartialEq, Clone, Serialize, Deserialize, Debug)]
-pub enum IpsCap {
-    V1(IpsCapV1),
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+pub enum Caps {
+    V0(CapSet<Cap>),
 }
 
-/// Potential capabilities for IPS
-#[derive(Ord, Eq, PartialOrd, PartialEq, Clone, Serialize, Deserialize, Debug)]
-#[repr(u8)]
-pub enum IpsCapV1 {
-    /// API tokens, used in the RPC
-    Api,
-    /// Used to authenticate users.
-    Web,
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Clone)]
+pub enum Cap {
+    All,
+    Blobs(CapSet<BlobsCap>),
+    Relay(CapSet<RelayCap>),
+    Metrics(CapSet<MetricsCap>),
 }
 
-impl Capability for IpsCap {
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Clone)]
+pub enum BlobsCap {
+    All,
+    PutBlob,
+    GetTag,
+}
+
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Clone)]
+pub enum MetricsCap {
+    PutAny,
+}
+
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Clone)]
+pub enum RelayCap {
+    UseUnlimited,
+}
+
+impl Caps {
+    pub fn new(caps: impl IntoIterator<Item = Cap>) -> Self {
+        Self::V0(CapSet::new(caps))
+    }
+
+    pub fn all() -> Self {
+        Self::new([Cap::All])
+    }
+}
+
+impl Capability for Caps {
+    fn can_delegate(&self, other: &Self) -> bool {
+        let Self::V0(slf) = self;
+        let Self::V0(other) = other;
+        slf.can_delegate(other)
+    }
+}
+
+impl Cap {
+    pub fn blobs(set: impl IntoIterator<Item = BlobsCap>) -> Self {
+        Self::Blobs(CapSet::new(set))
+    }
+
+    pub fn metrics(set: impl IntoIterator<Item = MetricsCap>) -> Self {
+        Self::Metrics(CapSet::new(set))
+    }
+
+    pub fn relay(set: impl IntoIterator<Item = RelayCap>) -> Self {
+        Self::Relay(CapSet::new(set))
+    }
+}
+
+impl Capability for Cap {
     fn can_delegate(&self, other: &Self) -> bool {
         match (self, other) {
-            (Self::V1(IpsCapV1::Web), Self::V1(IpsCapV1::Web)) => true,
-            (Self::V1(IpsCapV1::Api), Self::V1(IpsCapV1::Api)) => true,
-            (Self::V1(_), Self::V1(_)) => false,
+            (Cap::All, _) => true,
+            (Cap::Blobs(slf), Cap::Blobs(other)) => slf.can_delegate(other),
+            (Cap::Blobs(_), _) => false,
+            (Cap::Relay(slf), Cap::Relay(other)) => slf.can_delegate(other),
+            (Cap::Relay(_), _) => false,
+            (Cap::Metrics(slf), Cap::Metrics(other)) => slf.can_delegate(other),
+            (Cap::Metrics(_), _) => false,
         }
+    }
+}
+
+impl Capability for BlobsCap {
+    fn can_delegate(&self, other: &Self) -> bool {
+        match (self, other) {
+            (BlobsCap::All, _) => true,
+            (BlobsCap::PutBlob, BlobsCap::PutBlob) => true,
+            (BlobsCap::PutBlob, _) => false,
+            (BlobsCap::GetTag, BlobsCap::GetTag) => true,
+            (BlobsCap::GetTag, _) => false,
+        }
+    }
+}
+
+impl Capability for MetricsCap {
+    fn can_delegate(&self, other: &Self) -> bool {
+        match (self, other) {
+            (MetricsCap::PutAny, MetricsCap::PutAny) => true,
+        }
+    }
+}
+
+impl Capability for RelayCap {
+    fn can_delegate(&self, other: &Self) -> bool {
+        match (self, other) {
+            (RelayCap::UseUnlimited, RelayCap::UseUnlimited) => true,
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Clone)]
+pub struct CapSet<C: Capability + Ord>(BTreeSet<C>);
+
+impl<C: Capability + Ord> CapSet<C> {
+    pub fn new(set: impl IntoIterator<Item = C>) -> Self {
+        Self(BTreeSet::from_iter(set))
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &'_ C> + '_ {
+        self.0.iter()
+    }
+}
+
+impl<C: Capability + Ord> Capability for CapSet<C> {
+    fn can_delegate(&self, other: &Self) -> bool {
+        other
+            .iter()
+            .all(|other_cap| self.iter().any(|self_cap| self_cap.can_delegate(other_cap)))
     }
 }
 
@@ -37,7 +137,8 @@ pub fn create_api_token(
     user_ssh_key: &SshPrivateKey,
     local_node_id: NodeId,
     max_age: Duration,
-) -> Result<Rcan<IpsCap>> {
+    capability: Caps,
+) -> Result<Rcan<Caps>> {
     let issuer: SigningKey = user_ssh_key
         .key_data()
         .ed25519()
@@ -48,7 +149,46 @@ pub fn create_api_token(
 
     // TODO: add Into to iroh-base
     let audience = VerifyingKey::from_bytes(local_node_id.as_bytes())?;
-    let can = Rcan::issuing_builder(&issuer, audience, IpsCap::V1(IpsCapV1::Api))
-        .sign(Expires::valid_for(max_age));
+    let can =
+        Rcan::issuing_builder(&issuer, audience, capability).sign(Expires::valid_for(max_age));
     Ok(can)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn smoke() {
+        let all_listed = Caps::new([
+            Cap::blobs([BlobsCap::PutBlob, BlobsCap::GetTag]),
+            Cap::relay([RelayCap::UseUnlimited]),
+            Cap::metrics([MetricsCap::PutAny]),
+        ]);
+
+        let all = Caps::new([Cap::All]);
+
+        assert!(all.can_delegate(&all));
+        assert!(all.can_delegate(&all_listed));
+        assert!(!all_listed.can_delegate(&all));
+
+        let get_tags = Caps::new([Cap::blobs([BlobsCap::GetTag])]);
+        let put_blobs = Caps::new([Cap::blobs([BlobsCap::PutBlob])]);
+        let relay = Caps::new([Cap::relay([RelayCap::UseUnlimited])]);
+
+        for cap in [&get_tags, &put_blobs, &relay] {
+            assert!(all.can_delegate(&cap));
+            assert!(all_listed.can_delegate(&cap));
+            assert!(!cap.can_delegate(&all));
+            assert!(!cap.can_delegate(&all_listed));
+        }
+
+        assert!(!get_tags.can_delegate(&put_blobs));
+        assert!(!get_tags.can_delegate(&relay));
+
+        let all_blobs = Caps::new([Cap::blobs([BlobsCap::All])]);
+        assert!(all_blobs.can_delegate(&get_tags));
+        assert!(all_blobs.can_delegate(&put_blobs));
+        assert!(!put_blobs.can_delegate(&all_blobs));
+    }
 }

--- a/src/caps.rs
+++ b/src/caps.rs
@@ -1,15 +1,42 @@
-use std::{collections::BTreeSet, time::Duration};
+use std::{collections::BTreeSet, str::FromStr, time::Duration};
 
-use anyhow::{Context, Result};
-use ed25519_dalek::{SigningKey, VerifyingKey};
+use anyhow::{bail, Context, Result};
+use ed25519_dalek::SigningKey;
 use iroh::NodeId;
 use rcan::{Capability, Expires, Rcan};
 use serde::{Deserialize, Serialize};
 use ssh_key::PrivateKey as SshPrivateKey;
 
+macro_rules! cap_enum(
+    ($enum:item) => {
+        #[derive(
+            Debug,
+            Eq,
+            PartialEq,
+            Ord,
+            PartialOrd,
+            Serialize,
+            Deserialize,
+            Clone,
+            Copy,
+            strum::Display,
+            strum::EnumString,
+        )]
+        #[strum(serialize_all = "kebab-case")]
+        #[serde(rename_all = "kebab-case")]
+        $enum
+    }
+);
+
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
 pub enum Caps {
     V0(CapSet<Cap>),
+}
+
+impl Default for Caps {
+    fn default() -> Self {
+        Self::V0(CapSet::default())
+    }
 }
 
 impl std::ops::Deref for Caps {
@@ -21,38 +48,90 @@ impl std::ops::Deref for Caps {
     }
 }
 
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Clone)]
+#[derive(
+    Debug,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Serialize,
+    Deserialize,
+    Clone,
+    Copy,
+    derive_more::From,
+    strum::Display,
+)]
 pub enum Cap {
+    #[strum(to_string = "all")]
     All,
-    Blobs(CapSet<BlobsCap>),
-    Relay(CapSet<RelayCap>),
-    Metrics(CapSet<MetricsCap>),
+    #[strum(to_string = "blobs:{0}")]
+    Blobs(BlobsCap),
+    #[strum(to_string = "relay:{0}")]
+    Relay(RelayCap),
+    #[strum(to_string = "metrics:{0}")]
+    Metrics(MetricsCap),
 }
 
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Clone)]
-pub enum BlobsCap {
-    All,
-    PutBlob,
-    GetTag,
-}
+impl FromStr for Cap {
+    type Err = anyhow::Error;
 
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Clone)]
-pub enum MetricsCap {
-    PutAny,
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        if s == "all" {
+            Ok(Self::All)
+        } else if let Some((domain, inner)) = s.split_once(":") {
+            Ok(match domain {
+                "blobs" => Self::Blobs(BlobsCap::from_str(inner)?),
+                "metrics" => Self::Metrics(MetricsCap::from_str(inner)?),
+                "relay" => Self::Relay(RelayCap::from_str(inner)?),
+                _ => bail!("invalid cap domain"),
+            })
+        } else {
+            Err(anyhow::anyhow!("invalid cap string"))
+        }
+    }
 }
+cap_enum!(
+    pub enum BlobsCap {
+        All,
+        PutBlob,
+        GetTag,
+    }
+);
 
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Clone)]
-pub enum RelayCap {
-    UseUnlimited,
-}
+cap_enum!(
+    pub enum MetricsCap {
+        PutAny,
+    }
+);
+
+cap_enum!(
+    pub enum RelayCap {
+        UseUnlimited,
+    }
+);
 
 impl Caps {
-    pub fn new(caps: impl IntoIterator<Item = Cap>) -> Self {
+    pub fn new(caps: impl IntoIterator<Item = impl Into<Cap>>) -> Self {
         Self::V0(CapSet::new(caps))
     }
 
     pub fn all() -> Self {
         Self::new([Cap::All])
+    }
+
+    pub fn extend(self, caps: impl IntoIterator<Item = impl Into<Cap>>) -> Self {
+        let Self::V0(mut set) = self;
+        set.extend(caps.into_iter().map(Into::into));
+        Self::V0(set)
+    }
+
+    pub fn from_strs<'a>(strs: impl Iterator<Item = &'a str>) -> Result<Self> {
+        let mut caps = CapSet::default();
+        for s in strs {
+            let cap = Cap::from_str(s).with_context(|| "invalid cap string: {s}")?;
+            caps.insert(cap);
+        }
+        Ok(Self::V0(caps))
     }
 }
 
@@ -67,20 +146,6 @@ impl Capability for Caps {
 impl From<Cap> for Caps {
     fn from(cap: Cap) -> Self {
         Self::new([cap])
-    }
-}
-
-impl Cap {
-    pub fn blobs(set: impl IntoIterator<Item = BlobsCap>) -> Self {
-        Self::Blobs(CapSet::new(set))
-    }
-
-    pub fn metrics(set: impl IntoIterator<Item = MetricsCap>) -> Self {
-        Self::Metrics(CapSet::new(set))
-    }
-
-    pub fn relay(set: impl IntoIterator<Item = RelayCap>) -> Self {
-        Self::Relay(CapSet::new(set))
     }
 }
 
@@ -126,9 +191,15 @@ impl Capability for RelayCap {
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Clone)]
 pub struct CapSet<C: Capability + Ord>(BTreeSet<C>);
 
+impl<C: Capability + Ord> Default for CapSet<C> {
+    fn default() -> Self {
+        Self(BTreeSet::new())
+    }
+}
+
 impl<C: Capability + Ord> CapSet<C> {
-    pub fn new(set: impl IntoIterator<Item = C>) -> Self {
-        Self(BTreeSet::from_iter(set))
+    pub fn new(set: impl IntoIterator<Item = impl Into<C>>) -> Self {
+        Self(BTreeSet::from_iter(set.into_iter().map(Into::into)))
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &'_ C> + '_ {
@@ -143,8 +214,17 @@ impl<C: Capability + Ord> CapSet<C> {
         self.0.len()
     }
 
-    pub fn contains(&self, cap: &C) -> bool {
-        self.0.contains(cap)
+    pub fn contains(&self, cap: impl Into<C>) -> bool {
+        let cap = cap.into();
+        self.0.contains(&cap)
+    }
+
+    pub fn extend(&mut self, caps: impl IntoIterator<Item = impl Into<C>>) {
+        self.0.extend(caps.into_iter().map(Into::into));
+    }
+
+    pub fn insert(&mut self, cap: impl Into<C>) -> bool {
+        self.0.insert(cap.into())
     }
 }
 
@@ -171,8 +251,7 @@ pub fn create_api_token(
         .clone()
         .into();
 
-    // TODO: add Into to iroh-base
-    let audience = VerifyingKey::from_bytes(local_node_id.as_bytes())?;
+    let audience = local_node_id.public();
     let can =
         Rcan::issuing_builder(&issuer, audience, capability).sign(Expires::valid_for(max_age));
     Ok(can)
@@ -184,11 +263,26 @@ mod tests {
 
     #[test]
     fn smoke() {
-        let all_listed = Caps::new([
-            Cap::blobs([BlobsCap::PutBlob, BlobsCap::GetTag]),
-            Cap::relay([RelayCap::UseUnlimited]),
-            Cap::metrics([MetricsCap::PutAny]),
-        ]);
+        let all_listed = Caps::default()
+            .extend([BlobsCap::PutBlob, BlobsCap::GetTag])
+            .extend([RelayCap::UseUnlimited])
+            .extend([MetricsCap::PutAny]);
+
+        // test to-and-from string conversion
+        println!("all:     {:?}", all_listed);
+        let strings: Vec<String> = all_listed.iter().map(ToString::to_string).collect();
+        println!("strings: {:?}", strings);
+        let parsed = Caps::from_strs(strings.iter().map(|s| s.as_str())).unwrap();
+        println!("parsed:  {:?}", parsed);
+        assert_eq!(all_listed, parsed);
+
+        // manual parsing from strings
+        let s = ["blobs:put-blob", "relay:use-unlimited"];
+        let caps = Caps::from_strs(s.into_iter()).unwrap();
+        assert_eq!(
+            caps,
+            Caps::new([BlobsCap::PutBlob]).extend([RelayCap::UseUnlimited])
+        );
 
         let all = Caps::new([Cap::All]);
 
@@ -196,9 +290,9 @@ mod tests {
         assert!(all.permits(&all_listed));
         assert!(!all_listed.permits(&all));
 
-        let get_tags = Caps::new([Cap::blobs([BlobsCap::GetTag])]);
-        let put_blobs = Caps::new([Cap::blobs([BlobsCap::PutBlob])]);
-        let relay = Caps::new([Cap::relay([RelayCap::UseUnlimited])]);
+        let get_tags = Caps::new([BlobsCap::GetTag]);
+        let put_blobs = Caps::new([BlobsCap::PutBlob]);
+        let relay = Caps::new([RelayCap::UseUnlimited]);
 
         for cap in [&get_tags, &put_blobs, &relay] {
             assert!(all.permits(&cap));
@@ -210,7 +304,7 @@ mod tests {
         assert!(!get_tags.permits(&put_blobs));
         assert!(!get_tags.permits(&relay));
 
-        let all_blobs = Caps::new([Cap::blobs([BlobsCap::All])]);
+        let all_blobs = Caps::new([BlobsCap::All]);
         assert!(all_blobs.permits(&get_tags));
         assert!(all_blobs.permits(&put_blobs));
         assert!(!put_blobs.permits(&all_blobs));

--- a/src/caps.rs
+++ b/src/caps.rs
@@ -12,6 +12,15 @@ pub enum Caps {
     V0(CapSet<Cap>),
 }
 
+impl std::ops::Deref for Caps {
+    type Target = CapSet<Cap>;
+
+    fn deref(&self) -> &Self::Target {
+        let Self::V0(ref slf) = self;
+        slf
+    }
+}
+
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Clone)]
 pub enum Cap {
     All,
@@ -52,6 +61,12 @@ impl Capability for Caps {
         let Self::V0(slf) = self;
         let Self::V0(other) = other;
         slf.permits(other)
+    }
+}
+
+impl From<Cap> for Caps {
+    fn from(cap: Cap) -> Self {
+        Self::new([cap])
     }
 }
 
@@ -118,6 +133,18 @@ impl<C: Capability + Ord> CapSet<C> {
 
     pub fn iter(&self) -> impl Iterator<Item = &'_ C> + '_ {
         self.0.iter()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn contains(&self, cap: &C) -> bool {
+        self.0.contains(cap)
     }
 }
 

--- a/src/caps.rs
+++ b/src/caps.rs
@@ -94,6 +94,7 @@ cap_enum!(
     pub enum BlobsCap {
         All,
         PutBlob,
+        GetBlob,
         GetTag,
     }
 );
@@ -166,6 +167,7 @@ impl Capability for BlobsCap {
         match (self, other) {
             (BlobsCap::All, _) => true,
             (BlobsCap::PutBlob, BlobsCap::PutBlob) => true,
+            (BlobsCap::GetBlob, BlobsCap::GetBlob) => true,
             (BlobsCap::GetTag, BlobsCap::GetTag) => true,
             (_, _) => false,
         }
@@ -264,7 +266,7 @@ mod tests {
     #[test]
     fn smoke() {
         let all_listed = Caps::default()
-            .extend([BlobsCap::PutBlob, BlobsCap::GetTag])
+            .extend([BlobsCap::PutBlob, BlobsCap::GetBlob, BlobsCap::GetTag])
             .extend([RelayCap::UseUnlimited])
             .extend([MetricsCap::PutAny]);
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -3,7 +3,7 @@ use rcan::Rcan;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::caps::IpsCap;
+use crate::caps::Caps;
 
 pub const ALPN: &[u8] = b"/iroh/n0des/1";
 
@@ -12,7 +12,7 @@ pub const ALPN: &[u8] = b"/iroh/n0des/1";
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ServerMessage {
     /// Authentication on first request
-    Auth(Rcan<IpsCap>),
+    Auth(Rcan<Caps>),
     /// Request that the node fetches the given blob.
     PutBlob { ticket: BlobTicket, name: String },
     /// Request the name of a blob held by the node


### PR DESCRIPTION
This changes the capability definition to support all existing features, and be extensible.

The client constructor for now just creates a token with an `All` capability. We'll need to add a capability builder likely, but that doesn't have to be in the first round of changes (and in a way it only makes sense once we add delegation).

Note that this is a breaking change for the RPC.