### PR TITLE
refactor: switch RPC protocol to irpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,15 +291,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597bb81c80a54b6a4381b23faba8d7774b144c94cbd1d6fe3f1329bd776554ab"
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -798,18 +789,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "educe"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4bd92664bf78c4d3dba9b7cdafce6fa15b13ed3ed16175218196942e99168a8"
-dependencies = [
- "enum-ordinalize",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
 name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -847,26 +826,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
  "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "enum-ordinalize"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5"
-dependencies = [
- "enum-ordinalize-derive",
-]
-
-[[package]]
-name = "enum-ordinalize-derive"
-version = "4.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
-dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -1974,15 +1933,17 @@ dependencies = [
  "iroh-blobs",
  "iroh-gossip",
  "iroh-metrics",
+ "irpc",
+ "irpc-derive",
+ "irpc-iroh",
  "n0-future",
  "rand 0.8.5",
  "rcan",
  "serde",
  "ssh-key",
  "strum 0.27.1",
+ "thiserror 2.0.12",
  "tokio",
- "tokio-serde",
- "tokio-util",
  "tracing",
  "uuid",
 ]
@@ -2086,6 +2047,53 @@ dependencies = [
  "webpki-roots",
  "ws_stream_wasm",
  "z32",
+]
+
+[[package]]
+name = "irpc"
+version = "0.2.3"
+source = "git+https://github.com/n0-computer/irpc?branch=Frando/manual-accept-with-auth#4e138054cc634d9b4730bae68a29aff46b85b06a"
+dependencies = [
+ "anyhow",
+ "futures-buffered",
+ "futures-util",
+ "iroh-quinn",
+ "n0-future",
+ "postcard",
+ "rcgen",
+ "rustls",
+ "serde",
+ "smallvec",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "irpc-derive"
+version = "0.2.3"
+source = "git+https://github.com/n0-computer/irpc?branch=Frando/manual-accept-with-auth#4e138054cc634d9b4730bae68a29aff46b85b06a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "irpc-iroh"
+version = "0.2.3"
+source = "git+https://github.com/n0-computer/irpc?branch=Frando/manual-accept-with-auth#4e138054cc634d9b4730bae68a29aff46b85b06a"
+dependencies = [
+ "anyhow",
+ "getrandom 0.3.2",
+ "iroh",
+ "irpc",
+ "n0-future",
+ "postcard",
+ "serde",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4258,21 +4266,6 @@ checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
  "rustls",
  "tokio",
-]
-
-[[package]]
-name = "tokio-serde"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf600e7036b17782571dd44fa0a5cea3c82f60db5137f774a325a76a0d6852b"
-dependencies = [
- "bincode",
- "bytes",
- "educe",
- "futures-core",
- "futures-sink",
- "pin-project",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1934,7 +1934,6 @@ dependencies = [
  "iroh-gossip",
  "iroh-metrics",
  "irpc",
- "irpc-derive",
  "irpc-iroh",
  "n0-future",
  "rand 0.8.5",
@@ -2051,13 +2050,15 @@ dependencies = [
 
 [[package]]
 name = "irpc"
-version = "0.2.3"
-source = "git+https://github.com/n0-computer/irpc?branch=Frando/manual-accept-with-auth#4e138054cc634d9b4730bae68a29aff46b85b06a"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e645d8bb696998f4610287e650d2cbd09fe15b3668231de6c8d185156dc6e8a"
 dependencies = [
  "anyhow",
  "futures-buffered",
  "futures-util",
  "iroh-quinn",
+ "irpc-derive",
  "n0-future",
  "postcard",
  "rcgen",
@@ -2072,8 +2073,9 @@ dependencies = [
 
 [[package]]
 name = "irpc-derive"
-version = "0.2.3"
-source = "git+https://github.com/n0-computer/irpc?branch=Frando/manual-accept-with-auth#4e138054cc634d9b4730bae68a29aff46b85b06a"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7fa55af7f664a6dd2b790f422009a45d68620f9a63e43dc2da9fc1e1a4c8e01"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2082,8 +2084,9 @@ dependencies = [
 
 [[package]]
 name = "irpc-iroh"
-version = "0.2.3"
-source = "git+https://github.com/n0-computer/irpc?branch=Frando/manual-accept-with-auth#4e138054cc634d9b4730bae68a29aff46b85b06a"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2b7d0eb8e83d58682de32874b280d5db0a712e952b7676d1dd8437cc6c3f811"
 dependencies = [
  "anyhow",
  "getrandom 0.3.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ rust-version = "1.81"
 anyhow = "1.0.95"
 derive_more = { version = "2.0.1", features = ["from"] }
 ed25519-dalek = "2.1.1"
+irpc = { git = "https://github.com/n0-computer/irpc", branch = "Frando/manual-accept-with-auth" }
+irpc-derive = { git = "https://github.com/n0-computer/irpc", branch = "Frando/manual-accept-with-auth" }
+irpc-iroh = { git = "https://github.com/n0-computer/irpc", branch = "Frando/manual-accept-with-auth" }
 iroh = "0.35"
 iroh-blobs = "0.35"
 iroh-gossip = { version = "0.35", default-features = false }
@@ -24,9 +27,8 @@ rcan = { git = "https://github.com/n0-computer/rcan", branch = "main" }
 serde = { version = "1.0.217", features = ["derive"] }
 ssh-key = { version = "0.6.7", features = ["ed25519"] }
 strum = { version = "0.27.1", features = ["derive"] }
+thiserror = "2.0.12"
 tokio = "1.43.0"
-tokio-serde = { version = "0.9.0", features = ["bincode"] }
-tokio-util = { version = "0.7.13", features = ["codec"] }
 tracing = "0.1.41"
 uuid = { version = "1.12.1", features = ["v4", "serde"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,8 @@ rust-version = "1.81"
 anyhow = "1.0.95"
 derive_more = { version = "2.0.1", features = ["from"] }
 ed25519-dalek = "2.1.1"
-irpc = { git = "https://github.com/n0-computer/irpc", branch = "Frando/manual-accept-with-auth" }
-irpc-derive = { git = "https://github.com/n0-computer/irpc", branch = "Frando/manual-accept-with-auth" }
-irpc-iroh = { git = "https://github.com/n0-computer/irpc", branch = "Frando/manual-accept-with-auth" }
+irpc = "0.3.0"
+irpc-iroh = "0.3.0"
 iroh = "0.35"
 iroh-blobs = "0.35"
 iroh-gossip = { version = "0.35", default-features = false }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,32 +1,29 @@
 use std::{path::Path, time::Duration};
 
-use anyhow::{anyhow, ensure, Context, Result};
-use iroh::{
-    endpoint::{RecvStream, SendStream},
-    Endpoint, NodeAddr, NodeId,
-};
+use anyhow::{anyhow, ensure, Result};
+use iroh::{Endpoint, NodeAddr, NodeId};
 use iroh_blobs::{ticket::BlobTicket, BlobFormat, Hash};
 use iroh_gossip::proto::TopicId;
 use iroh_metrics::{MetricsSource, Registry};
-use n0_future::{task::AbortOnDropHandle, SinkExt, StreamExt};
+use irpc_iroh::IrohRemoteConnection;
+use n0_future::task::AbortOnDropHandle;
 use rand::Rng;
 use rcan::Rcan;
-use tokio::sync::{mpsc, oneshot};
-use tokio_serde::formats::Bincode;
-use tokio_util::codec::{FramedRead, FramedWrite, LengthDelimitedCodec};
-use tracing::{debug, warn};
+use tracing::warn;
 use uuid::Uuid;
 
 use crate::{
     caps::Caps,
-    protocol::{ClientMessage, ServerMessage, ALPN},
+    protocol::{
+        Auth, DeleteTopic, GetTag, N0desClient, Ping, PutBlob, PutMetrics, PutTopic, RemoteError,
+        ALPN,
+    },
 };
 
 #[derive(Debug)]
 pub struct Client {
-    sender: mpsc::Sender<ActorMessage>,
-    _actor_task: AbortOnDropHandle<()>,
-    cap: Rcan<Caps>,
+    client: N0desClient,
+    _metrics_task: Option<AbortOnDropHandle<()>>,
 }
 
 /// Constructs an IPS client
@@ -91,56 +88,63 @@ impl ClientBuilder {
     }
 
     /// Create a new client, connected to the provide service node
-    pub async fn build(self, remote: impl Into<NodeAddr>) -> Result<Client> {
-        let cap = self.cap.context("missing capability")?;
+    pub async fn build(self, remote: impl Into<NodeAddr>) -> Result<Client, BuildError> {
+        let cap = self.cap.ok_or(BuildError::MissingCapability)?;
+        let conn = IrohRemoteConnection::new(self.endpoint.clone(), remote.into(), ALPN.to_vec());
+        let client = N0desClient::boxed(conn);
 
-        let remote_addr = remote.into();
-        let connection = self.endpoint.connect(remote_addr.clone(), ALPN).await?;
+        // If auth fails, the connection is aborted.
+        let () = client.rpc(Auth { caps: cap }).await?;
 
-        let (send_stream, recv_stream) = connection.open_bi().await?;
-
-        // Delimit frames using a length header
-        let length_delimited_read = FramedRead::new(recv_stream, LengthDelimitedCodec::new());
-        let length_delimited_write = FramedWrite::new(send_stream, LengthDelimitedCodec::new());
-
-        // Deserialize frames
-        let reader = tokio_serde::Framed::new(
-            length_delimited_read,
-            Bincode::<ClientMessage, ServerMessage>::default(),
-        );
-
-        let writer = tokio_serde::Framed::new(
-            length_delimited_write,
-            Bincode::<ClientMessage, ServerMessage>::default(),
-        );
-
-        let (internal_sender, internal_receiver) = mpsc::channel(64);
-
-        let actor = Actor {
-            metrics: None,
-            endpoint: self.endpoint,
-            reader,
-            writer,
-            internal_receiver,
-            internal_sender: internal_sender.clone(),
-            session_id: Uuid::new_v4(),
-        };
-        let enable_metrics = self.enable_metrics;
-        let run_handle = tokio::task::spawn(async move {
-            actor.run(enable_metrics).await;
+        let metrics_task = self.enable_metrics.map(|interval| {
+            AbortOnDropHandle::new(n0_future::task::spawn(
+                MetricsTask {
+                    client: client.clone(),
+                    session_id: Uuid::new_v4(),
+                    endpoint: self.endpoint.clone(),
+                }
+                .run(interval),
+            ))
         });
-        let actor_task = AbortOnDropHandle::new(run_handle);
 
-        let mut this = Client {
-            cap,
-            sender: internal_sender,
-            _actor_task: actor_task,
-        };
-
-        this.authenticate().await?;
-
-        Ok(this)
+        Ok(Client {
+            client,
+            _metrics_task: metrics_task,
+        })
     }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum BuildError {
+    #[error("Missing capability")]
+    MissingCapability,
+    #[error("Unauthorized")]
+    Unauthorized,
+    #[error("Remote error: {0}")]
+    Remote(#[from] RemoteError),
+    #[error("Connection error: {0}")]
+    Rpc(irpc::Error),
+}
+
+impl From<irpc::Error> for BuildError {
+    fn from(value: irpc::Error) -> Self {
+        match value {
+            irpc::Error::Request(irpc::RequestError::Connection(
+                iroh::endpoint::ConnectionError::ApplicationClosed(frame),
+            )) if frame.error_code == 401u32.into() => Self::Unauthorized,
+            value @ _ => Self::Rpc(value),
+        }
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("Remote error: {0}")]
+    Remote(#[from] RemoteError),
+    #[error("Connection error: {0}")]
+    Rpc(#[from] irpc::Error),
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
 }
 
 impl Client {
@@ -148,17 +152,15 @@ impl Client {
         ClientBuilder::new(endpoint)
     }
 
-    /// Trigger the auth handshake with the server
-    async fn authenticate(&mut self) -> Result<()> {
-        let (s, r) = oneshot::channel();
-        self.sender
-            .send(ActorMessage::Auth {
-                rcan: self.cap.clone(),
-                s,
-            })
-            .await?;
-        r.await??;
-        Ok(())
+    /// Pings the remote node.
+    pub async fn ping(&mut self) -> Result<(), Error> {
+        let req = rand::thread_rng().gen();
+        let pong = self.client.rpc(Ping { req }).await?;
+        if pong.req == req {
+            Ok(())
+        } else {
+            Err(Error::Other(anyhow!("unexpected pong response")))
+        }
     }
 
     /// Transfer the blob from the local iroh node to the service node.
@@ -168,32 +170,16 @@ impl Client {
         hash: Hash,
         format: BlobFormat,
         name: String,
-    ) -> Result<()> {
+    ) -> Result<(), Error> {
         let ticket = BlobTicket::new(node.into(), hash, format)?;
-
-        let (s, r) = oneshot::channel();
-        self.sender
-            .send(ActorMessage::PutBlob { ticket, name, s })
-            .await?;
-        r.await??;
-        Ok(())
-    }
-
-    /// Pings the remote node.
-    pub async fn ping(&mut self) -> Result<()> {
-        let (s, r) = oneshot::channel();
-        let req = rand::thread_rng().gen();
-        self.sender.send(ActorMessage::Ping { req, s }).await?;
-        r.await??;
+        self.client.rpc(PutBlob { name, ticket }).await??;
         Ok(())
     }
 
     /// Get the `Hash` behind the tag, if available.
-    pub async fn get_tag(&mut self, name: String) -> Result<Hash> {
-        let (s, r) = oneshot::channel();
-        self.sender.send(ActorMessage::GetTag { name, s }).await?;
-        let res = r.await??;
-        Ok(res)
+    pub async fn get_tag(&mut self, name: String) -> Result<Option<Hash>, Error> {
+        let maybe_hash = self.client.rpc(GetTag { name }).await??;
+        Ok(maybe_hash)
     }
 
     /// Create a gossip topic.
@@ -202,299 +188,57 @@ impl Client {
         topic: TopicId,
         label: String,
         bootstrap: Vec<NodeId>,
-    ) -> Result<()> {
-        let (s, r) = oneshot::channel();
-        self.sender
-            .send(ActorMessage::PutTopic {
-                topic,
+    ) -> Result<(), Error> {
+        self.client
+            .rpc(PutTopic {
+                topic: *topic.as_bytes(),
                 label,
                 bootstrap,
-                s,
             })
-            .await?;
-        r.await??;
+            .await??;
         Ok(())
     }
 
     /// Delete a gossip topic.
-    pub async fn delete_gossip_topic(&mut self, topic: TopicId) -> Result<()> {
-        let (s, r) = oneshot::channel();
-        self.sender
-            .send(ActorMessage::DeleteTopic { topic, s })
-            .await?;
-        r.await??;
+    pub async fn delete_gossip_topic(&mut self, topic: TopicId) -> Result<(), Error> {
+        self.client
+            .rpc(DeleteTopic {
+                topic: *topic.as_bytes(),
+            })
+            .await??;
         Ok(())
     }
 }
 
-struct Actor {
-    metrics: Option<Registry>,
-    endpoint: Endpoint,
-    reader: tokio_serde::Framed<
-        FramedRead<RecvStream, LengthDelimitedCodec>,
-        ClientMessage,
-        ServerMessage,
-        Bincode<ClientMessage, ServerMessage>,
-    >,
-    writer: tokio_serde::Framed<
-        FramedWrite<SendStream, LengthDelimitedCodec>,
-        ClientMessage,
-        ServerMessage,
-        Bincode<ClientMessage, ServerMessage>,
-    >,
-    internal_receiver: mpsc::Receiver<ActorMessage>,
-    internal_sender: mpsc::Sender<ActorMessage>,
+struct MetricsTask {
+    client: N0desClient,
     session_id: Uuid,
+    endpoint: Endpoint,
 }
 
-#[allow(clippy::large_enum_variant)]
-enum ActorMessage {
-    Auth {
-        rcan: Rcan<Caps>,
-        s: oneshot::Sender<anyhow::Result<()>>,
-    },
-    PutBlob {
-        ticket: BlobTicket,
-        name: String,
-        s: oneshot::Sender<anyhow::Result<()>>,
-    },
-    Ping {
-        req: [u8; 32],
-        s: oneshot::Sender<anyhow::Result<()>>,
-    },
-    PutMetrics {
-        encoded: String,
-        session_id: Uuid,
-        s: oneshot::Sender<anyhow::Result<()>>,
-    },
-    GetTag {
-        name: String,
-        s: oneshot::Sender<anyhow::Result<Hash>>,
-    },
-    PutTopic {
-        topic: iroh_gossip::proto::TopicId,
-        label: String,
-        bootstrap: Vec<NodeId>,
-        s: oneshot::Sender<anyhow::Result<()>>,
-    },
-    DeleteTopic {
-        topic: iroh_gossip::proto::TopicId,
-        s: oneshot::Sender<anyhow::Result<()>>,
-    },
-}
-
-impl Actor {
-    async fn run(mut self, enable_metrics: Option<Duration>) {
-        if enable_metrics.is_some() {
-            let mut registry = Registry::default();
-            registry.register_all(self.endpoint.metrics());
-            self.metrics = Some(registry);
-        }
-        let metrics_time = enable_metrics.unwrap_or_else(|| Duration::from_secs(60 * 60 * 24));
-        let mut metrics_timer = tokio::time::interval(metrics_time);
+impl MetricsTask {
+    async fn run(self, interval: Duration) {
+        let mut registry = Registry::default();
+        registry.register_all(self.endpoint.metrics());
+        let mut metrics_timer = tokio::time::interval(interval);
 
         loop {
-            tokio::select! {
-                biased;
-                msg = self.internal_receiver.recv() => {
-                    match msg {
-                        Some(server_msg) => {
-                            self.handle_message(server_msg).await;
-                        }
-                        None => {
-                            break;
-                        }
-                    }
-                }
-                _ = metrics_timer.tick(), if enable_metrics.is_some() => {
-                    debug!("metrics_timer::tick()");
-                    self.send_metrics().await;
-                }
-            }
-        }
-
-        debug!("shutting down");
-    }
-
-    async fn handle_message(&mut self, msg: ActorMessage) {
-        match msg {
-            ActorMessage::Auth { rcan, s } => {
-                if let Err(err) = self.writer.send(ServerMessage::Auth(rcan)).await {
-                    s.send(Err(err.into())).ok();
-                    return;
-                }
-
-                let response = match self.reader.next().await {
-                    Some(Ok(msg)) => match msg {
-                        ClientMessage::AuthResponse(None) => Ok(()),
-                        ClientMessage::AuthResponse(Some(err)) => {
-                            Err(anyhow!("failed to authenticate: {}", err))
-                        }
-                        _ => Err(anyhow!("unexpected message from server: {:?}", msg)),
-                    },
-                    Some(Err(err)) => Err(anyhow!("auth: failed to receive response: {:?}", err)),
-                    None => Err(anyhow!("auth: connection closed")),
-                };
-                s.send(response).ok();
-            }
-            ActorMessage::PutBlob { ticket, name, s } => {
-                if let Err(err) = self
-                    .writer
-                    .send(ServerMessage::PutBlob { name, ticket })
-                    .await
-                {
-                    s.send(Err(err.into())).ok();
-                    return;
-                }
-                let response = match self.reader.next().await {
-                    Some(Ok(msg)) => match msg {
-                        ClientMessage::PutBlobResponse(None) => Ok(()),
-                        ClientMessage::PutBlobResponse(Some(err)) => {
-                            Err(anyhow!("upload failed: {}", err))
-                        }
-                        _ => Err(anyhow!("unexpected message from server: {:?}", msg)),
-                    },
-                    Some(Err(err)) => Err(anyhow!("failed to receive response: {:?}", err)),
-                    None => Err(anyhow!("connection closed")),
-                };
-                s.send(response).ok();
-            }
-            ActorMessage::GetTag { name, s } => {
-                if let Err(err) = self.writer.send(ServerMessage::GetTag { name }).await {
-                    s.send(Err(err.into())).ok();
-                    return;
-                };
-                let response = match self.reader.next().await {
-                    Some(Ok(msg)) => match msg {
-                        ClientMessage::GetTagResponse(maybe_hash) => match maybe_hash {
-                            Some(hash) => Ok(hash),
-                            None => Err(anyhow!("blob not found")),
-                        },
-                        _ => Err(anyhow!("unexpected response: {:?}", msg)),
-                    },
-                    Some(Err(err)) => Err(anyhow!("failed to receive response: {:?}", err)),
-                    None => Err(anyhow!("connection closed")),
-                };
-                s.send(response).ok();
-            }
-            ActorMessage::PutMetrics {
-                encoded,
-                session_id,
-                s,
-            } => {
-                let response = self
-                    .writer
-                    .send(ServerMessage::PutMetrics {
-                        encoded,
-                        session_id,
-                    })
-                    .await;
-                // we don't expect a response
-                s.send(response.map_err(Into::into)).ok();
-            }
-            ActorMessage::Ping { req, s } => {
-                if let Err(err) = self.writer.send(ServerMessage::Ping { req }).await {
-                    s.send(Err(err.into())).ok();
-                    return;
-                }
-
-                let response = match self.reader.next().await {
-                    Some(Ok(msg)) => match msg {
-                        ClientMessage::Pong { req: req_back } => {
-                            if req_back != req {
-                                Err(anyhow!("unexpected pong response"))
-                            } else {
-                                Ok(())
-                            }
-                        }
-                        _ => Err(anyhow!("unexpected message from server: {:?}", msg)),
-                    },
-                    Some(Err(err)) => Err(anyhow!("failed to receive response: {:?}", err)),
-                    None => Err(anyhow!("connection closed")),
-                };
-                s.send(response).ok();
-            }
-            ActorMessage::PutTopic {
-                topic,
-                label,
-                bootstrap,
-                s,
-            } => {
-                if let Err(err) = self
-                    .writer
-                    .send(ServerMessage::PutTopic {
-                        topic: *topic.as_bytes(),
-                        label,
-                        bootstrap,
-                    })
-                    .await
-                {
-                    s.send(Err(err.into())).ok();
-                    return;
-                }
-                let response = match self.reader.next().await {
-                    Some(Ok(msg)) => match msg {
-                        ClientMessage::PutTopicResponse(None) => Ok(()),
-                        ClientMessage::PutTopicResponse(Some(err)) => {
-                            Err(anyhow!("put topic failed: {}", err))
-                        }
-                        _ => Err(anyhow!("unexpected message from server: {:?}", msg)),
-                    },
-                    Some(Err(err)) => Err(anyhow!("failed to receive response: {:?}", err)),
-                    None => Err(anyhow!("connection closed")),
-                };
-                s.send(response).ok();
-            }
-            ActorMessage::DeleteTopic { topic, s } => {
-                if let Err(err) = self
-                    .writer
-                    .send(ServerMessage::DeleteTopic {
-                        topic: *topic.as_bytes(),
-                    })
-                    .await
-                {
-                    s.send(Err(err.into())).ok();
-                    return;
-                }
-                let response = match self.reader.next().await {
-                    Some(Ok(msg)) => match msg {
-                        ClientMessage::DeleteTopicResponse(None) => Ok(()),
-                        ClientMessage::DeleteTopicResponse(Some(err)) => {
-                            Err(anyhow!("delete topic failed: {}", err))
-                        }
-                        _ => Err(anyhow!("unexpected message from server: {:?}", msg)),
-                    },
-                    Some(Err(err)) => Err(anyhow!("failed to receive response: {:?}", err)),
-                    None => Err(anyhow!("connection closed")),
-                };
-                s.send(response).ok();
+            metrics_timer.tick().await;
+            if let Err(err) = self.send_metrics(&registry).await {
+                warn!("failed to push metrics: {:#?}", err);
             }
         }
     }
 
-    async fn send_metrics(&mut self) {
-        if let Some(registry) = &self.metrics {
-            let dump = registry
-                .encode_openmetrics_to_string()
-                .expect("this never fails");
-
-            let (s, r) = oneshot::channel();
-            if let Err(err) = self
-                .internal_sender
-                .send(ActorMessage::PutMetrics {
-                    encoded: dump,
-                    session_id: self.session_id,
-                    s,
-                })
-                .await
-            {
-                warn!("failed to send internal message: {:?}", err);
-            }
-            // spawn a task, to not block the run loop
-            tokio::task::spawn(async move {
-                let res = r.await;
-                debug!("metrics sent: {:?}", res);
-            });
-        }
+    async fn send_metrics(&self, registry: &iroh_metrics::Registry) -> Result<()> {
+        let dump = registry
+            .encode_openmetrics_to_string()
+            .expect("this never fails");
+        let req = PutMetrics {
+            session_id: self.session_id,
+            encoded: dump,
+        };
+        self.client.rpc(req).await??;
+        Ok(())
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -132,7 +132,7 @@ impl From<irpc::Error> for BuildError {
             irpc::Error::Request(irpc::RequestError::Connection(
                 iroh::endpoint::ConnectionError::ApplicationClosed(frame),
             )) if frame.error_code == 401u32.into() => Self::Unauthorized,
-            value @ _ => Self::Rpc(value),
+            value => Self::Rpc(value),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 mod client;
-mod protocol;
 
 pub mod caps;
+pub mod protocol;
 
 pub use self::{
     client::{Client, ClientBuilder},
-    protocol::{ClientMessage, ServerMessage, ALPN},
+    protocol::ALPN,
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,7 +69,7 @@ pub async fn main() -> Result<()> {
 
     println!("downloaded blob: {:?}", blob);
 
-    let server_hash = rpc_client.get_tag(name).await?;
+    let server_hash = rpc_client.get_tag(name).await?.unwrap();
     assert_eq!(server_hash, client_blob.hash);
 
     println!("waiting for Ctrl+C..");

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -20,6 +20,7 @@ impl Service for N0desService {}
 
 #[rpc_requests(N0desService, message = N0desMessage)]
 #[derive(Debug, Serialize, Deserialize)]
+#[allow(clippy::large_enum_variant)]
 pub enum N0desProtocol {
     #[rpc(tx=oneshot::Sender<()>)]
     Auth(Auth),

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,8 +1,7 @@
 use anyhow::Result;
 use iroh::NodeId;
 use iroh_blobs::{ticket::BlobTicket, Hash};
-use irpc::{channel::oneshot, Service};
-use irpc_derive::rpc_requests;
+use irpc::{channel::oneshot, rpc_requests, Service};
 use rcan::Rcan;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,5 +1,8 @@
+use anyhow::Result;
 use iroh::NodeId;
 use iroh_blobs::{ticket::BlobTicket, Hash};
+use irpc::{channel::oneshot, Service};
+use irpc_derive::rpc_requests;
 use rcan::Rcan;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -8,50 +11,95 @@ use crate::caps::Caps;
 
 pub const ALPN: &[u8] = b"/iroh/n0des/1";
 
-pub type ProtoTopicId = [u8; 32];
+pub type N0desClient = irpc::Client<N0desMessage, N0desProtocol, N0desService>;
 
-/// Messages sent from the client to the server
-#[allow(clippy::large_enum_variant)]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum ServerMessage {
-    /// Authentication on first request
-    Auth(Rcan<Caps>),
-    /// Request that the node fetches the given blob.
-    PutBlob { ticket: BlobTicket, name: String },
-    /// Request that the node joins the given tossip topic
-    PutTopic {
-        topic: ProtoTopicId,
-        label: String,
-        bootstrap: Vec<NodeId>,
-    },
-    /// Request that the node joins the given tossip topic
-    DeleteTopic { topic: ProtoTopicId },
-    /// Request the name of a blob held by the node
-    GetTag { name: String },
-    /// Request to store the given metrics data
-    PutMetrics { encoded: String, session_id: Uuid },
-    /// Simple ping requests
-    Ping { req: [u8; 32] },
+#[derive(Debug, Clone, Copy)]
+pub struct N0desService;
+
+impl Service for N0desService {}
+
+#[rpc_requests(N0desService, message = N0desMessage)]
+#[derive(Debug, Serialize, Deserialize)]
+pub enum N0desProtocol {
+    #[rpc(tx=oneshot::Sender<()>)]
+    Auth(Auth),
+    #[rpc(tx=oneshot::Sender<RemoteResult<()>>)]
+    PutBlob(PutBlob),
+    #[rpc(tx=oneshot::Sender<RemoteResult<Option<Hash>>>)]
+    GetTag(GetTag),
+    #[rpc(tx=oneshot::Sender<RemoteResult<()>>)]
+    PutTopic(PutTopic),
+    #[rpc(tx=oneshot::Sender<RemoteResult<()>>)]
+    DeleteTopic(DeleteTopic),
+    #[rpc(tx=oneshot::Sender<RemoteResult<()>>)]
+    PutMetrics(PutMetrics),
+    #[rpc(tx=oneshot::Sender<Pong>)]
+    Ping(Ping),
 }
 
-/// Messages sent from the server to the client
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum ClientMessage {
-    // Empty reply
-    Ack,
-    /// Authentication response
-    /// if set, error, otherwise ok
-    AuthResponse(Option<String>),
-    /// If set, this means it was an error.
-    PutBlobResponse(Option<String>),
-    /// If set, this means it was an error.
-    PutTopicResponse(Option<String>),
-    /// If set, this means it was an error.
-    DeleteTopicResponse(Option<String>),
-    /// Simple pong response
-    Pong {
-        req: [u8; 32],
-    },
-    // if **missing**, means there was an error
-    GetTagResponse(Option<Hash>),
+pub type RemoteResult<T> = Result<T, RemoteError>;
+
+// #[derive(Debug, Serialize, Deserialize)]
+// pub struct RemoteError(pub String);
+
+#[derive(Serialize, Deserialize, thiserror::Error, Debug)]
+pub enum RemoteError {
+    #[error("Missing capability: {}", _0.to_strings().join(", "))]
+    MissingCapability(Caps),
+    #[error("Internal server error")]
+    InternalServerError,
+}
+
+/// Authentication on first request
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Auth {
+    pub caps: Rcan<Caps>,
+}
+
+/// Request that the node fetches the given blob.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PutBlob {
+    pub ticket: BlobTicket,
+    pub name: String,
+}
+
+/// Request the name of a blob held by the node
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetTag {
+    pub name: String,
+}
+
+pub type ProtoTopicId = [u8; 32];
+
+/// Request that the node joins the given tossip topic
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PutTopic {
+    pub topic: ProtoTopicId,
+    pub label: String,
+    pub bootstrap: Vec<NodeId>,
+}
+
+/// Request that the node joins the given tossip topic
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DeleteTopic {
+    pub topic: ProtoTopicId,
+}
+
+/// Request to store the given metrics data
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PutMetrics {
+    pub encoded: String,
+    pub session_id: Uuid,
+}
+
+/// Simple ping requests
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Ping {
+    pub req: [u8; 32],
+}
+
+/// Simple ping response
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Pong {
+    pub req: [u8; 32],
 }


### PR DESCRIPTION
Supersedes #15 

Moves the RPC protocol to irpc.

* Moves the RPC protocol to irpc.
* Auth flow is unchanged
* When a request fails for missing caps, we no longer terminate the connection but instead return an error response and continue processing requests
* Improved RPC error handling: Only expose `MissingCap(caps)` and `InternalServerError` over the RPC boundary. Actual anyhow errors are only `warn!` logged but not sent as strings.