### PR TITLE
feat: trace protocol and simulation runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1638,8 +1638,7 @@ dependencies = [
 [[package]]
 name = "iroh-ping"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de531c839b4cf1a414b5c35bf32233a1de06a0935d0fe533448c745d9e784a25"
+source = "git+https://github.com/Frando/iroh-ping?branch=Frando%2Fdont-close-endpoint#7d668018844a0d1bdc30f1b80e9a9f682e3cbd0e"
 dependencies = [
  "anyhow",
  "iroh",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,20 @@
 version = 4
 
 [[package]]
+name = "acto"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a026259da4f1a13b4af60cda453c392de64c58c12d239c560923e0382f42f2b9"
+dependencies = [
+ "parking_lot",
+ "pin-project-lite",
+ "rustc_version",
+ "smol_str",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -548,6 +562,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -1528,6 +1543,7 @@ dependencies = [
  "strum 0.26.3",
  "stun-rs",
  "surge-ping",
+ "swarm-discovery",
  "time",
  "tokio",
  "tokio-stream",
@@ -1594,6 +1610,7 @@ dependencies = [
  "iroh-metrics",
  "iroh-n0des-macro",
  "iroh-ping",
+ "iroh-quinn",
  "irpc",
  "irpc-iroh",
  "n0-future",
@@ -1603,6 +1620,7 @@ dependencies = [
  "ssh-key",
  "strum 0.27.1",
  "thiserror 2.0.12",
+ "time",
  "tokio",
  "tracing",
  "uuid",
@@ -3281,6 +3299,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smol_str"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fad6c857cbab2627dcf01ec85a623ca4e7dcb5691cbaa3d7fb7653671f0d09c9"
+
+[[package]]
 name = "snafu"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3470,6 +3494,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "swarm-discovery"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eae338a4551897c6a50fa2c041c4b75f578962d9fca8adb828cf81f7158740f"
+dependencies = [
+ "acto",
+ "hickory-proto",
+ "rand 0.9.1",
+ "socket2",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3603,11 +3642,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
+ "itoa",
  "js-sys",
  "num-conv",
  "powerfmt",
  "serde",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -3615,6 +3656,16 @@ name = "time-core"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+
+[[package]]
+name = "time-macros"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinystr"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,6 +1592,7 @@ dependencies = [
  "ed25519-dalek",
  "iroh",
  "iroh-metrics",
+ "iroh-ping",
  "irpc",
  "irpc-iroh",
  "n0-future",
@@ -1604,6 +1605,18 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "iroh-ping"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de531c839b4cf1a414b5c35bf32233a1de06a0935d0fe533448c745d9e784a25"
+dependencies = [
+ "anyhow",
+ "iroh",
+ "iroh-metrics",
+ "n0-snafu",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,6 +1592,7 @@ dependencies = [
  "ed25519-dalek",
  "iroh",
  "iroh-metrics",
+ "iroh-n0des-macro",
  "iroh-ping",
  "irpc",
  "irpc-iroh",
@@ -1605,6 +1606,15 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "iroh-n0des-macro"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1617,6 +1617,7 @@ dependencies = [
  "rand 0.8.5",
  "rcan",
  "serde",
+ "serde_json",
  "ssh-key",
  "strum 0.27.1",
  "thiserror 2.0.12",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1623,6 +1623,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -3895,6 +3896,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3904,12 +3915,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ tokio = "1.45"
 tracing = "0.1.41"
 uuid = { version = "1.17", features = ["v4", "serde"] }
 time = { version = "0.3.41", features = ["serde", "serde-well-known"] }
+tracing-subscriber = { version = "0.3.19", features = ["env-filter", "fmt", "json"] }
 
 [dev-dependencies]
 iroh-ping = { git = "https://github.com/Frando/iroh-ping", branch = "Frando/dont-close-endpoint" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ uuid = { version = "1.17", features = ["v4", "serde"] }
 time = { version = "0.3.41", features = ["serde", "serde-well-known"] }
 
 [dev-dependencies]
-iroh-ping = "0.2.0"
+iroh-ping = { git = "https://github.com/Frando/iroh-ping", branch = "Frando/dont-close-endpoint" }
 
 [workspace]
 members = ["iroh-n0des-macro"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,10 @@ strum = { version = "0.27.1", features = ["derive"] }
 thiserror = "2.0.12"
 tokio = "1.45"
 tracing = "0.1.41"
-uuid = { version = "1.17", features = ["v4", "serde"] }
+uuid = { version = "1.17", features = ["v4", "serde", "v7"] }
 time = { version = "0.3.41", features = ["serde", "serde-well-known"] }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "fmt", "json"] }
+serde_json = "1.0.140"
 
 [dev-dependencies]
 iroh-ping = { git = "https://github.com/Frando/iroh-ping", branch = "Frando/dont-close-endpoint" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ ed25519-dalek = "2.1.1"
 irpc = "0.5.0"
 irpc-iroh = "0.5.0"
 iroh = "0.90"
+iroh-n0des-macro = { path = "iroh-n0des-macro" }
 iroh-metrics = "0.35"
 n0-future = "0.1.2"
 rand = "0.8"
@@ -31,3 +32,6 @@ uuid = { version = "1.17", features = ["v4", "serde"] }
 
 [dev-dependencies]
 iroh-ping = "0.2.0"
+
+[workspace]
+members = ["iroh-n0des-macro"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,6 @@ thiserror = "2.0.12"
 tokio = "1.45"
 tracing = "0.1.41"
 uuid = { version = "1.17", features = ["v4", "serde"] }
+
+[dev-dependencies]
+iroh-ping = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,11 @@ derive_more = { version = "2.0.1", features = ["from"] }
 ed25519-dalek = "2.1.1"
 irpc = "0.5.0"
 irpc-iroh = "0.5.0"
-iroh = "0.90"
+iroh = { version = "0.90", features = ["discovery-local-network"] }
 iroh-n0des-macro = { path = "iroh-n0des-macro" }
 iroh-metrics = "0.35"
 n0-future = "0.1.2"
+quinn = { package = "iroh-quinn", version = "0.14.0", default-features = false }
 rand = "0.8"
 rcan = "0.1.0"
 serde = { version = "1.0.217", features = ["derive"] }
@@ -29,6 +30,7 @@ thiserror = "2.0.12"
 tokio = "1.45"
 tracing = "0.1.41"
 uuid = { version = "1.17", features = ["v4", "serde"] }
+time = { version = "0.3.41", features = ["serde", "serde-well-known"] }
 
 [dev-dependencies]
 iroh-ping = "0.2.0"

--- a/iroh-n0des-macro/Cargo.toml
+++ b/iroh-n0des-macro/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "iroh-n0des-macro"
+version = "0.1.0"
+edition = "2021"
+authors = ["n0 team"]
+keywords = []
+categories = []
+license = "Apache-2.0/MIT"
+repository = "https://github.com/n0-computer/iroh-n0des"
+description = "Macros for iroh-n0des"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "1", features = ["full"] }
+quote = "1"
+proc-macro2 = "1"

--- a/iroh-n0des-macro/src/lib.rs
+++ b/iroh-n0des-macro/src/lib.rs
@@ -1,0 +1,22 @@
+use proc_macro::TokenStream;
+
+/// Marks a function as a simulation test
+///
+/// This is a simple marker attribute that doesn't transform the code.
+/// The external test runner discovers these functions by parsing the AST
+/// and looking for this attribute.
+#[proc_macro_attribute]
+pub fn sim(_args: TokenStream, input: TokenStream) -> TokenStream {
+    // Parse and validate the function signature
+    let input_fn = syn::parse_macro_input!(input as syn::ItemFn);
+
+    // Validate it's async and returns Result<SimulationBuilder<_>>
+    if input_fn.sig.asyncness.is_none() {
+        return syn::Error::new_spanned(input_fn.sig.fn_token, "sim functions must be async")
+            .to_compile_error()
+            .into();
+    }
+
+    // Return original function unchanged
+    TokenStream::from(quote::quote! { #input_fn })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@ pub mod caps;
 pub mod protocol;
 pub mod simulation;
 
+pub use iroh_n0des_macro::sim;
+
 pub use self::{
     client::{Client, ClientBuilder},
     n0des::N0de,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,9 @@ pub mod simulation;
 
 pub use iroh_n0des_macro::sim;
 
+// This lets us use the derive metrics in the lib tests within this crate.
+extern crate self as iroh_n0des;
+
 pub use self::{
     client::{Client, ClientBuilder},
     n0des::N0de,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ mod n0des;
 
 pub mod caps;
 pub mod protocol;
+pub mod simulation;
 
 pub use self::{
     client::{Client, ClientBuilder},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,3 +12,5 @@ pub use self::{
     n0des::N0de,
     protocol::ALPN,
 };
+
+pub use iroh_metrics::Registry;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use anyhow::Result;
 use iroh::{Endpoint, NodeAddr, NodeId};
 use iroh_n0des::Client;
@@ -25,13 +27,15 @@ pub async fn main() -> Result<()> {
 
     // Create iroh services client
     let mut rpc_client = Client::builder(&client_endpoint)
-        // .metrics_interval(Duration::from_secs(2))
+        .metrics_interval(Duration::from_secs(2))
         .ssh_key(&alice_ssh_key)?
         .build(remote_node_addr.clone())
         .await?;
 
     rpc_client.ping().await?;
     println!("ping OK");
+    // waiting to push some metrics
+    tokio::time::sleep(Duration::from_secs(4)).await;
     client_endpoint.close().await;
 
     Ok(())

--- a/src/n0des.rs
+++ b/src/n0des.rs
@@ -5,7 +5,7 @@ use iroh::Endpoint;
 use iroh_metrics::Registry;
 
 /// A trait for nodes that can be spawned and shut down
-pub trait N0de: 'static + Send {
+pub trait N0de: 'static + Send + Sync {
     fn spawn(
         endpoint: Endpoint,
         metrics: &mut Registry,

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -1,0 +1,220 @@
+use std::{marker::PhantomData, sync::Arc};
+
+use anyhow::Result;
+use iroh::{Endpoint, NodeAddr, NodeId, Watcher};
+use iroh_metrics::Registry;
+use n0_future::boxed::BoxFuture;
+use tokio::sync::RwLock;
+
+use crate::n0des::N0de;
+
+/// A registry to collect endpoint metrics for spawned nodes in a simulation
+type MetricsRegistry = Arc<RwLock<Registry>>;
+
+/// Simulation context passed to each node
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct Context {
+    pub round: usize,
+    pub node_index: usize,
+    pub addrs: Vec<NodeAddr>,
+}
+
+impl Context {
+    #[allow(dead_code)]
+    fn all_other_nodes(&self, me: NodeId) -> Vec<NodeAddr> {
+        let mut other_nodes = Vec::new();
+        for id in self.addrs.iter() {
+            if id.node_id != me {
+                other_nodes.push(id.clone());
+            }
+        }
+        other_nodes
+    }
+}
+
+pub struct Simulation<N: N0de> {
+    max_ticks: usize,
+    #[allow(clippy::type_complexity)]
+    round: Box<dyn Fn(&Context, &N) -> BoxFuture<Result<bool>>>,
+    #[allow(clippy::type_complexity)]
+    check: Option<Box<dyn Fn(&Context, &N) -> Result<()>>>,
+    nodes: Vec<N>,
+    context: Context,
+}
+
+impl<N: N0de> Simulation<N> {
+    #[allow(dead_code)]
+    fn builder(
+        round: impl Fn(&Context, &N) -> BoxFuture<Result<bool>> + 'static,
+    ) -> SimulationBuilder<N> {
+        SimulationBuilder::<N> {
+            max_ticks: 100,
+            nodes: 2,
+            round: Box::new(round),
+            check: None,
+            _node: PhantomData,
+        }
+    }
+
+    #[allow(dead_code)]
+    async fn run(&self) -> Result<()> {
+        for round_num in 0..self.max_ticks {
+            println!("Round {round_num}");
+            for (i, n) in self.nodes.iter().enumerate() {
+                let mut ctx = self.context.clone();
+                ctx.round = round_num;
+                ctx.node_index = i;
+
+                (self.round)(&ctx, n).await?;
+            }
+
+            println!("Round {round_num} completed");
+            if let Some(check) = &self.check {
+                for (i, n) in self.nodes.iter().enumerate() {
+                    let mut ctx = self.context.clone();
+                    ctx.round = round_num;
+                    ctx.node_index = i;
+
+                    (check)(&ctx, n)?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+pub struct SimulationBuilder<N: N0de> {
+    max_ticks: usize,
+    nodes: u32,
+    #[allow(clippy::type_complexity)]
+    round: Box<dyn Fn(&Context, &N) -> BoxFuture<Result<bool>>>,
+    #[allow(clippy::type_complexity)]
+    check: Option<Box<dyn Fn(&Context, &N) -> Result<()>>>,
+    _node: PhantomData<N>,
+}
+
+impl<N: N0de> SimulationBuilder<N> {
+    pub fn max_ticks(self, count: usize) -> Self {
+        Self {
+            max_ticks: count,
+            ..self
+        }
+    }
+
+    pub fn check(self, check: impl Fn(&Context, &N) -> Result<()> + 'static) -> Self {
+        Self {
+            check: Some(Box::new(check)),
+            ..self
+        }
+    }
+
+    pub async fn build(self) -> Result<Simulation<N>> {
+        let mut nodes = vec![];
+        let mut addrs = vec![];
+
+        let registry: MetricsRegistry = Arc::new(RwLock::new(Registry::default()));
+
+        // initialize nodes
+        for _ in 0..self.nodes {
+            let ep = Endpoint::builder()
+                .known_nodes(addrs.clone())
+                .bind()
+                .await?;
+            let addr = ep.node_addr().initialized().await?;
+            addrs.push(addr);
+
+            let mut registry = registry.write().await;
+            let sub = registry.sub_registry_with_label("node", ep.node_id().to_string());
+            sub.register_all(ep.metrics());
+
+            let node = N::spawn(ep, sub).await?;
+            nodes.push(node);
+        }
+
+        let context = Context {
+            round: 0,
+            node_index: 0,
+            addrs,
+        };
+
+        Ok(Simulation {
+            max_ticks: self.max_ticks,
+            round: self.round,
+            check: self.check,
+            nodes,
+            context,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use iroh::protocol::Router;
+
+    use super::*;
+    use iroh_ping::{Ping, ALPN as PingALPN};
+
+    struct ExampleN0de {
+        ping: Ping,
+        router: Router,
+    }
+
+    impl N0de for ExampleN0de {
+        async fn spawn(ep: Endpoint, metrics: &mut Registry) -> Result<Self> {
+            let ping = Ping::new();
+            metrics.register(ping.metrics().clone());
+
+            let router = iroh::protocol::Router::builder(ep)
+                .accept(PingALPN, ping.clone())
+                .spawn();
+
+            Ok(Self { ping, router })
+        }
+
+        async fn shutdown(&mut self) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_simulation() {
+        let tick = |ctx: &Context, node: &ExampleN0de| -> BoxFuture<Result<bool>> {
+            let me = node.router.endpoint().node_id();
+            let other_nodes = ctx.all_other_nodes(me);
+            let ping = node.ping.clone();
+            let endpoint = node.router.endpoint().clone();
+            let node_index = ctx.node_index;
+
+            Box::pin(async move {
+                if node_index % 2 == 0 {
+                    for other in other_nodes.iter() {
+                        println!("Sending message:\n\tfrom: {me}\n\t to:   {}", other.node_id);
+                        ping.ping(&endpoint, (other.clone()).into()).await?;
+                    }
+                }
+                Ok(true)
+            })
+        };
+
+        let check = |ctx: &Context, node: &ExampleN0de| -> Result<()> {
+            let metrics = node.ping.metrics();
+            let node_count = ctx.addrs.len() as u64;
+            match ctx.node_index % 2 {
+                0 => assert_eq!(metrics.pings_sent.get(), node_count / 2),
+                _ => assert_eq!(metrics.pings_recv.get(), node_count / 2),
+            }
+            Ok(())
+        };
+
+        let sim: Simulation<ExampleN0de> = Simulation::builder(tick)
+            .max_ticks(1) // currently stuck on one tick, because more ends with an "endpoint closing" error
+            .check(check)
+            .build()
+            .await
+            .unwrap();
+
+        sim.run().await.unwrap();
+    }
+}

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -475,6 +475,7 @@ mod tests {
         };
         super::trace::try_init_global_subscriber();
         let trace_client = client.start_trace("foo", TraceKind::Test {}).await?;
+
         tracing::info!("hello world");
         let span = tracing::info_span!("req", id = 1, method = "get");
         let _guard = span.enter();

--- a/src/simulation/proto.rs
+++ b/src/simulation/proto.rs
@@ -56,6 +56,12 @@ pub struct SimClient {
 }
 
 impl SimClient {
+    pub fn from_addr_str(addr: &str) -> Result<Self> {
+        let addr: SocketAddr = addr.parse()?;
+        let client = SimClient::new_quinn_insecure(addr)?;
+        Ok(client)
+    }
+
     pub fn new_quinn_insecure(remote: SocketAddr) -> Result<Self> {
         let addr_localhost = "127.0.0.1:0".parse().unwrap();
         let endpoint = make_insecure_client_endpoint(addr_localhost)?;
@@ -80,10 +86,10 @@ impl SimClient {
         Self { client, session_id }
     }
 
-    pub(crate) fn session(&self, simulation_name: String) -> SimSession {
+    pub(crate) fn session(&self, simulation_name: &str) -> SimSession {
         SimSession {
             client: self.clone(),
-            simulation_name,
+            simulation_name: simulation_name.to_string(),
         }
     }
 }

--- a/src/simulation/proto.rs
+++ b/src/simulation/proto.rs
@@ -1,0 +1,115 @@
+use std::net::SocketAddr;
+
+use anyhow::Result;
+use iroh::{Endpoint, NodeAddr, NodeId};
+use irpc::{channel::oneshot, rpc_requests, util::make_insecure_client_endpoint, Service};
+use irpc_iroh::IrohRemoteConnection;
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime as DateTime;
+use uuid::Uuid;
+
+use crate::N0de;
+
+use super::{Context, SimNode};
+
+pub const ALPN: &[u8] = b"/iroh/n0des-sim/1";
+
+#[derive(Debug, Clone, Copy)]
+pub struct SimService;
+
+impl Service for SimService {}
+
+pub type RemoteResult<T> = Result<T, RemoteError>;
+
+#[derive(Serialize, Deserialize, thiserror::Error, Debug)]
+pub enum RemoteError {
+    #[error("{0}")]
+    Other(String),
+}
+
+#[rpc_requests(SimService, message = SimMessage)]
+#[derive(Debug, Serialize, Deserialize)]
+#[allow(clippy::large_enum_variant)]
+pub enum SimProtocol {
+    #[rpc(tx=oneshot::Sender<RemoteResult<()>>)]
+    PutMetrics(PutMetrics),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PutMetrics {
+    pub session_id: Uuid,
+    pub simulation_name: String,
+    pub node_id: NodeId,
+    pub round: u64,
+    #[serde(with = "time::serde::rfc3339")]
+    pub timestamp: DateTime,
+    pub metrics: iroh_metrics::encoding::Update,
+}
+
+#[derive(Debug, Clone)]
+pub struct SimClient {
+    client: irpc::Client<SimMessage, SimProtocol, SimService>,
+    session_id: Uuid,
+}
+
+impl SimClient {
+    pub fn new_quinn_insecure(remote: SocketAddr) -> Result<Self> {
+        let addr_localhost = "127.0.0.1:0".parse().unwrap();
+        let endpoint = make_insecure_client_endpoint(addr_localhost)?;
+        Ok(Self::connect_quinn(endpoint, remote))
+    }
+
+    pub fn connect_quinn(endpoint: quinn::Endpoint, remote: SocketAddr) -> Self {
+        let client = irpc::Client::quinn(endpoint, remote);
+        let session_id = Uuid::new_v4();
+        Self { client, session_id }
+    }
+
+    pub async fn new_iroh(remote: NodeId) -> Result<Self> {
+        let endpoint = Endpoint::builder().discovery_local_network().bind().await?;
+        Ok(Self::connect_iroh(endpoint, remote))
+    }
+
+    pub fn connect_iroh(endpoint: Endpoint, remote: impl Into<NodeAddr>) -> Self {
+        let conn = IrohRemoteConnection::new(endpoint, remote.into(), ALPN.to_vec());
+        let client = irpc::Client::boxed(conn);
+        let session_id = Uuid::new_v4();
+        Self { client, session_id }
+    }
+
+    pub(crate) fn session(&self, simulation_name: String) -> SimSession {
+        SimSession {
+            client: self.clone(),
+            simulation_name,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SimSession {
+    client: SimClient,
+    simulation_name: String,
+}
+
+impl SimSession {
+    pub(crate) async fn put_metrics<N: N0de>(
+        &self,
+        context: &Context,
+        node: &mut SimNode<N>,
+    ) -> Result<()> {
+        let timestamp = DateTime::now_utc();
+        let update = node.encoder.export();
+        self.client
+            .client
+            .rpc(PutMetrics {
+                session_id: self.client.session_id.clone(),
+                simulation_name: self.simulation_name.clone(),
+                node_id: node.endpoint.node_id(),
+                round: context.round,
+                timestamp,
+                metrics: update,
+            })
+            .await??;
+        Ok(())
+    }
+}

--- a/src/simulation/proto.rs
+++ b/src/simulation/proto.rs
@@ -2,14 +2,12 @@ use std::net::SocketAddr;
 
 use anyhow::Result;
 use iroh::{Endpoint, NodeAddr, NodeId};
-use iroh_metrics::encoding::Encoder;
+use iroh_metrics::encoding::Update;
 use irpc::{channel::oneshot, rpc_requests, util::make_insecure_client_endpoint, Service};
 use irpc_iroh::IrohRemoteConnection;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime as DateTime;
 use uuid::Uuid;
-
-use super::RoundOutcome;
 
 pub const ALPN: &[u8] = b"/iroh/n0des-sim/1";
 
@@ -26,51 +24,91 @@ pub enum RemoteError {
     Other(String),
 }
 
-#[rpc_requests(SimService, message = SimMessage)]
 #[derive(Debug, Serialize, Deserialize)]
+#[rpc_requests(SimService, message = SimMessage)]
 #[allow(clippy::large_enum_variant)]
 pub enum SimProtocol {
     #[rpc(tx=oneshot::Sender<RemoteResult<()>>)]
-    StartSim(StartSim),
+    StartTrace(StartTrace),
     #[rpc(tx=oneshot::Sender<RemoteResult<()>>)]
-    PutMetrics(PutMetrics),
+    EndTrace(EndTrace),
     #[rpc(tx=oneshot::Sender<RemoteResult<()>>)]
-    EndSim(EndSim),
+    PutCheckpoint(PutCheckpoint),
+    #[rpc(tx=oneshot::Sender<RemoteResult<()>>)]
+    Logs(PutLogs),
+    #[rpc(tx=oneshot::Sender<RemoteResult<()>>)]
+    Metrics(PutMetrics),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct StartSim {
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct StartTrace {
+    pub trace_id: Uuid,
     pub session_id: Uuid,
-    pub simulation_name: String,
+    pub name: String,
+    pub kind: TraceKind,
     #[serde(with = "time::serde::rfc3339")]
     pub start_time: DateTime,
-    pub node_count: u64,
-    pub round_count: u64,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct EndSim {
-    pub session_id: Uuid,
-    pub simulation_name: String,
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub enum TraceKind {
+    Simulation(SimulationInfo),
+    Test {},
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SimulationInfo {
+    pub nodes: Vec<NodeInfo>,
+    pub expected_rounds: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct NodeInfo {
+    pub node_id: NodeId,
+    pub node_index: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct EndTrace {
+    pub trace_id: Uuid,
     #[serde(with = "time::serde::rfc3339")]
     pub end_time: DateTime,
     pub result: Result<(), String>,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PutLogs {
+    pub trace_id: Uuid,
+    // pub round_idx: Option<RoundIdx>,
+    pub json_lines: Vec<String>,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PutMetrics {
-    pub session_id: Uuid,
-    pub simulation_name: String,
+    pub trace_id: Uuid,
     pub node_id: NodeId,
-    pub node_index: usize,
-    pub round: u64,
+    pub checkpoint_id: Option<CheckpointId>,
     #[serde(with = "time::serde::rfc3339")]
-    pub end_time: DateTime,
-    #[serde(with = "time::serde::rfc3339")]
-    pub start_time: DateTime,
-    pub duration_micros: u64,
+    pub time: DateTime,
     pub metrics: iroh_metrics::encoding::Update,
-    pub logs: Option<String>,
+}
+
+pub type CheckpointId = u64;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PutCheckpoint {
+    pub trace_id: Uuid,
+    pub checkpoint_id: CheckpointId,
+    pub node_stats: Vec<NodeStats>,
+    pub label: Option<String>,
+    #[serde(with = "time::serde::rfc3339")]
+    pub time: DateTime,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct NodeStats {
+    pub node_id: NodeId,
+    pub round_duration_ms: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -94,7 +132,7 @@ impl SimClient {
 
     pub fn connect_quinn(endpoint: quinn::Endpoint, remote: SocketAddr) -> Self {
         let client = irpc::Client::quinn(endpoint, remote);
-        let session_id = Uuid::new_v4();
+        let session_id = Uuid::now_v7();
         Self { client, session_id }
     }
 
@@ -110,72 +148,128 @@ impl SimClient {
         Self { client, session_id }
     }
 
-    pub(crate) async fn session(
-        &self,
-        simulation_name: &str,
-        node_count: u64,
-        round_count: u64,
-    ) -> Result<SimSession> {
+    pub(crate) async fn start_trace(&self, name: &str, kind: TraceKind) -> Result<TraceClient> {
         let start_time = DateTime::now_utc();
+        let trace_id = Uuid::now_v7();
         self.client
-            .rpc(StartSim {
+            .rpc(StartTrace {
+                trace_id,
                 session_id: self.session_id,
-                simulation_name: simulation_name.to_string(),
+                name: name.to_string(),
+                kind,
                 start_time,
-                node_count,
-                round_count,
             })
             .await??;
-        Ok(SimSession {
-            client: self.clone(),
-            simulation_name: simulation_name.to_string(),
+        Ok(TraceClient {
+            client: self.client.clone(),
+            trace_id,
         })
     }
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct SimSession {
-    client: SimClient,
-    simulation_name: String,
+pub(crate) struct TraceClient {
+    client: irpc::Client<SimMessage, SimProtocol, SimService>,
+    trace_id: Uuid,
 }
 
-impl SimSession {
-    pub(crate) async fn put_round(
+impl TraceClient {
+    pub(crate) async fn put_checkpoint(
         &self,
-        outcome: RoundOutcome,
-        metrics_encoder: &mut Encoder,
-        logs: Option<String>,
+        id: CheckpointId,
+        label: Option<String>,
+        node_stats: Vec<NodeStats>,
     ) -> Result<()> {
-        let update = metrics_encoder.export();
+        let time = DateTime::now_utc();
         self.client
-            .client
-            .rpc(PutMetrics {
-                session_id: self.client.session_id.clone(),
-                simulation_name: self.simulation_name.clone(),
-                node_id: outcome.node_id,
-                node_index: outcome.node_index,
-                round: outcome.round,
-                start_time: outcome.start_time,
-                end_time: outcome.end_time,
-                duration_micros: outcome.duration.as_micros() as u64,
-                metrics: update,
-                logs,
+            .rpc(PutCheckpoint {
+                trace_id: self.trace_id,
+                checkpoint_id: id,
+                node_stats,
+                time,
+                label,
             })
             .await??;
         Ok(())
     }
 
-    pub(crate) async fn finalize(&self, result: Result<(), String>) -> Result<()> {
+    pub(crate) async fn put_metrics(
+        &self,
+        node_id: NodeId,
+        checkpoint_id: Option<CheckpointId>,
+        metrics: Update,
+    ) -> Result<()> {
+        let time = DateTime::now_utc();
+        self.client
+            .rpc(PutMetrics {
+                trace_id: self.trace_id,
+                node_id,
+                checkpoint_id,
+                time,
+                metrics,
+            })
+            .await??;
+        Ok(())
+    }
+
+    pub(crate) async fn put_logs(&self, json_lines: Vec<String>) -> Result<()> {
+        self.client
+            .rpc(PutLogs {
+                trace_id: self.trace_id,
+                json_lines,
+            })
+            .await??;
+        Ok(())
+    }
+
+    pub(crate) async fn close(&self, result: Result<(), String>) -> Result<()> {
         let end_time = DateTime::now_utc();
         self.client
-            .client
-            .rpc(EndSim {
-                session_id: self.client.session_id.clone(),
-                simulation_name: self.simulation_name.clone(),
+            .rpc(EndTrace {
+                trace_id: self.trace_id,
                 end_time,
                 result,
             })
             .await??;
         Ok(())
     }
+
+    // pub(crate) async fn put_round(
+    //     &self,
+    //     outcome: RoundOutcome,
+    //     metrics_encoder: &mut Encoder,
+    //     logs: Option<String>,
+    // ) -> Result<()> {
+    //     let update = metrics_encoder.export();
+    //     self.client
+    //         .client
+    //         .rpc(PutMetrics {
+    //             session_id: self.client.session_id.clone(),
+    //             simulation_name: self.simulation_name.clone(),
+    //             node_id: outcome.node_id,
+    //             node_index: outcome.node_index,
+    //             round: outcome.round,
+    //             start_time: outcome.start_time,
+    //             end_time: outcome.end_time,
+    //             duration_micros: outcome.duration.as_micros() as u64,
+    //             metrics: update,
+    //             logs,
+    //         })
+    //         .await??;
+    //     Ok(())
+    // }
+
+    // pub(crate) async fn finalize(&self, result: Result<(), String>) -> Result<()> {
+    //     let end_time = DateTime::now_utc();
+    //     self.client
+    //         .client
+    //         .rpc(EndSim {
+    //             session_id: self.client.session_id.clone(),
+    //             simulation_name: self.simulation_name.clone(),
+    //             end_time,
+    //             result,
+    //         })
+    //         .await??;
+    //     Ok(())
+    // }
 }

--- a/src/simulation/trace.rs
+++ b/src/simulation/trace.rs
@@ -1,54 +1,25 @@
 use std::{
-    cell::RefCell,
-    collections::HashMap,
-    io,
-    sync::{Arc, Mutex, MutexGuard, OnceLock},
+    io::BufRead,
+    sync::{Arc, Mutex, OnceLock},
 };
 
-use tracing::{
-    span::{Attributes, Id},
-    Subscriber,
-};
 use tracing_subscriber::{
-    fmt::MakeWriter,
-    layer::{Context, SubscriberExt},
-    registry::LookupSpan,
+    fmt::{writer::MutexGuardWriter, MakeWriter},
+    layer::SubscriberExt,
     util::SubscriberInitExt,
     EnvFilter, Layer,
 };
 
-pub type BucketId = Option<usize>;
-pub type Buckets = Arc<Mutex<HashMap<BucketId, Vec<u8>>>>;
-pub type BucketsGuard<'a> = MutexGuard<'a, HashMap<BucketId, Vec<u8>>>;
-
-// pub(crate) fn print_bucket_stats() {
-//     let buckets = get_buckets();
-//     let buckets = buckets.lock().unwrap();
-//     for (k, v) in buckets.iter() {
-//         println!("KEY {k:?} has {}", v.len());
-//     }
-// }
-
-// pub(crate) fn write_buckets() -> anyhow::Result<()> {
-//     let path = std::path::PathBuf::from("./logs");
-//     std::fs::create_dir_all(&path)?;
-//     let buckets = get_buckets();
-//     let buckets = buckets.lock().unwrap();
-//     for (k, v) in buckets.iter() {
-//         let filename = match k {
-//             None => format!("other.log"),
-//             Some(i) => format!("node-{i}.log"),
-//         };
-//         let path = path.join(filename);
-//         std::fs::write(path, v)?;
-//     }
-//     Ok(())
-// }
+use super::proto::TraceClient;
 
 pub(crate) fn try_init_global_subscriber() {
+    static DID_INIT: OnceLock<bool> = OnceLock::new();
+    if DID_INIT.set(true).is_err() {
+        return;
+    }
+    tracing::info!("setting up irpc tracing subscriber");
     let print_layer = {
-        let default_directive = format!("{}=debug,iroh=info", env!("CARGO_CRATE_NAME"));
-        let directive = std::env::var("RUST_LOG").unwrap_or_else(|_| default_directive.to_string());
+        let directive = std::env::var("RUST_LOG").unwrap_or_else(|_| "".to_string());
         let filter = EnvFilter::new(directive);
         tracing_subscriber::fmt::layer()
             .with_writer(|| TestWriter)
@@ -57,37 +28,33 @@ pub(crate) fn try_init_global_subscriber() {
             .with_filter(filter)
     };
 
-    let buckets = get_buckets();
-    let bucket_writer = BucketWriter { buckets };
+    let writer = global_writer();
     let json_layer = {
         let default_directive = "debug".to_string();
         let directive = std::env::var("SIM_LOG").unwrap_or_else(|_| default_directive.to_string());
         let filter = EnvFilter::new(directive);
         tracing_subscriber::fmt::layer()
             .json()
-            .with_writer(bucket_writer)
+            .with_writer(writer)
             .with_filter(filter)
     };
 
     let registry = tracing_subscriber::registry()
-        .with(SimNodeTracker)
         .with(json_layer)
         .with(print_layer);
 
     registry.try_init().ok();
 }
 
-pub(crate) fn get_buckets() -> Buckets {
-    static BUCKETS: OnceLock<Buckets> = OnceLock::new();
-    BUCKETS.get_or_init(|| Default::default()).clone()
+pub(crate) fn global_writer() -> LineWriter {
+    static WRITER: OnceLock<LineWriter> = OnceLock::new();
+    WRITER.get_or_init(|| Default::default()).clone()
 }
 
-pub(crate) fn clear_bucket(idx: usize) -> Option<String> {
-    let buckets = get_buckets();
-    let mut buckets = buckets.lock().expect("poisoned");
-    let bucket = buckets.get_mut(&Some(idx))?;
-    let content = std::mem::take(bucket);
-    String::from_utf8(content).ok()
+pub(crate) async fn submit_logs(client: &TraceClient) -> anyhow::Result<()> {
+    let writer = global_writer();
+    writer.submit(client).await?;
+    Ok(())
 }
 
 /// A tracing writer that interacts well with test output capture.
@@ -110,123 +77,41 @@ impl std::io::Write for TestWriter {
     }
 }
 
-struct BucketWriter {
-    buckets: Buckets,
+#[derive(Clone, Default)]
+pub struct LineWriter {
+    buf: Arc<Mutex<Vec<u8>>>,
 }
 
-impl<'a> MakeWriter<'a> for BucketWriter {
-    type Writer = BucketGuardWriter<'a>;
+impl<'a> MakeWriter<'a> for LineWriter {
+    type Writer = MutexGuardWriter<'a, Vec<u8>>;
 
     fn make_writer(&'a self) -> Self::Writer {
-        let state = CURRENT_SIM_NODE.with(|tls| tls.borrow().clone());
-        let node = state.map(|(_id, val)| val);
-        BucketGuardWriter(node, self.buckets.lock().unwrap())
+        self.buf.make_writer()
     }
 }
 
-pub struct BucketGuardWriter<'a>(BucketId, BucketsGuard<'a>);
-
-impl<'a> BucketGuardWriter<'a> {
-    fn get(&mut self) -> &mut dyn std::io::Write {
-        self.1.entry(self.0).or_default()
-    }
-}
-
-impl io::Write for BucketGuardWriter<'_> {
-    #[inline]
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.get().write(buf)
+impl LineWriter {
+    pub fn clear(&self) {
+        self.buf.lock().expect("lock poisoned").clear();
     }
 
-    #[inline]
-    fn flush(&mut self) -> io::Result<()> {
-        self.get().flush()
-    }
-
-    #[inline]
-    fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
-        self.get().write_vectored(bufs)
-    }
-
-    #[inline]
-    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
-        self.get().write_all(buf)
-    }
-
-    #[inline]
-    fn write_fmt(&mut self, fmt: std::fmt::Arguments<'_>) -> io::Result<()> {
-        self.get().write_fmt(fmt)
-    }
-}
-
-thread_local! {
-    static CURRENT_SIM_NODE: RefCell<Option<(Id, usize)>> = RefCell::new(None);
-}
-
-pub struct SimNodeTracker;
-
-impl<S> Layer<S> for SimNodeTracker
-where
-    S: Subscriber + for<'a> LookupSpan<'a>,
-{
-    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
-        if attrs.metadata().name() == "sim-node" {
-            let span = ctx.span(id).unwrap();
-            let mut visitor = FindSimNode(None);
-            attrs.record(&mut visitor);
-            if let Some(node) = visitor.0 {
-                span.extensions_mut().insert(SimNode(node));
-            }
-        }
-    }
-
-    fn on_enter(&self, id: &Id, ctx: Context<'_, S>) {
-        if let Some(span) = ctx.span(id) {
-            if let Some(sim) = span.extensions().get::<SimNode>() {
-                CURRENT_SIM_NODE.with(|tls| *tls.borrow_mut() = Some((id.clone(), sim.0)));
-            } else {
-                let mut current = span.parent();
-                while let Some(span) = current {
-                    if let Some(sim) = span.extensions().get::<SimNode>() {
-                        CURRENT_SIM_NODE.with(|tls| *tls.borrow_mut() = Some((id.clone(), sim.0)));
-                        break;
+    pub async fn submit(&self, client: &TraceClient) -> anyhow::Result<()> {
+        let lines = {
+            let mut buf = self.buf.lock().expect("lock poisoned");
+            let lines = buf
+                .lines()
+                .filter_map(|line| match line {
+                    Ok(line) => Some(line),
+                    Err(err) => {
+                        tracing::warn!("Skipping invalid log line: {err:?}");
+                        None
                     }
-                    current = span.parent();
-                }
-            }
-        }
-    }
-
-    fn on_exit(&self, id: &Id, _ctx: Context<'_, S>) {
-        // Clear the value on exit
-        CURRENT_SIM_NODE.with(|tls| {
-            let mut inner = tls.borrow_mut();
-            if let Some((last_id, _)) = inner.as_mut() {
-                if id == last_id {
-                    *inner = None;
-                }
-            }
-        });
+                })
+                .collect();
+            buf.clear();
+            lines
+        };
+        client.put_logs(lines).await?;
+        Ok(())
     }
 }
-
-struct FindSimNode(pub Option<usize>);
-
-impl tracing::field::Visit for FindSimNode {
-    fn record_u64(&mut self, field: &tracing::field::Field, val: u64) {
-        if field.name() == "idx" {
-            self.0 = Some(val as usize);
-        }
-    }
-
-    fn record_i64(&mut self, field: &tracing::field::Field, val: i64) {
-        if field.name() == "idx" && val >= 0 {
-            self.0 = Some(val as usize);
-        }
-    }
-
-    fn record_debug(&mut self, _field: &tracing::field::Field, _value: &dyn std::fmt::Debug) {}
-}
-
-#[derive(Debug)]
-struct SimNode(pub usize);

--- a/src/simulation/trace.rs
+++ b/src/simulation/trace.rs
@@ -64,7 +64,7 @@ pub(crate) fn try_init_global_subscriber() {
         let directive = std::env::var("SIM_LOG").unwrap_or_else(|_| default_directive.to_string());
         let filter = EnvFilter::new(directive);
         tracing_subscriber::fmt::layer()
-            // .json()
+            .json()
             .with_writer(bucket_writer)
             .with_filter(filter)
     };

--- a/src/simulation/trace.rs
+++ b/src/simulation/trace.rs
@@ -60,7 +60,7 @@ pub(crate) fn try_init_global_subscriber() {
     let buckets = get_buckets();
     let bucket_writer = BucketWriter { buckets };
     let json_layer = {
-        let default_directive = format!("{}=debug,iroh=debug", env!("CARGO_CRATE_NAME"));
+        let default_directive = "debug".to_string();
         let directive = std::env::var("SIM_LOG").unwrap_or_else(|_| default_directive.to_string());
         let filter = EnvFilter::new(directive);
         tracing_subscriber::fmt::layer()

--- a/src/simulation/trace.rs
+++ b/src/simulation/trace.rs
@@ -47,20 +47,22 @@ pub type BucketsGuard<'a> = MutexGuard<'a, HashMap<BucketId, Vec<u8>>>;
 
 pub(crate) fn try_init_global_subscriber() {
     let print_layer = {
-        let env_filter = format!("{}=trace,iroh=info", env!("CARGO_CRATE_NAME"));
-        let print_filter = std::env::var("RUST_LOG").unwrap_or_else(|_| env_filter.to_string());
-        let print_filter = EnvFilter::new(print_filter);
+        let default_directive = format!("{}=debug,iroh=info", env!("CARGO_CRATE_NAME"));
+        let directive = std::env::var("RUST_LOG").unwrap_or_else(|_| default_directive.to_string());
+        let filter = EnvFilter::new(directive);
         tracing_subscriber::fmt::layer()
             .with_writer(|| TestWriter)
             .event_format(tracing_subscriber::fmt::format().with_line_number(true))
             .with_level(true)
-            .with_filter(print_filter)
+            .with_filter(filter)
     };
 
     let buckets = get_buckets();
     let bucket_writer = BucketWriter { buckets };
     let json_layer = {
-        let filter = EnvFilter::new("debug");
+        let default_directive = format!("{}=debug,iroh=debug", env!("CARGO_CRATE_NAME"));
+        let directive = std::env::var("SIM_LOG").unwrap_or_else(|_| default_directive.to_string());
+        let filter = EnvFilter::new(directive);
         tracing_subscriber::fmt::layer()
             // .json()
             .with_writer(bucket_writer)

--- a/src/simulation/trace.rs
+++ b/src/simulation/trace.rs
@@ -1,0 +1,230 @@
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    io,
+    sync::{Arc, Mutex, MutexGuard, OnceLock},
+};
+
+use tracing::{
+    span::{Attributes, Id},
+    Subscriber,
+};
+use tracing_subscriber::{
+    fmt::MakeWriter,
+    layer::{Context, SubscriberExt},
+    registry::LookupSpan,
+    util::SubscriberInitExt,
+    EnvFilter, Layer,
+};
+
+pub type BucketId = Option<usize>;
+pub type Buckets = Arc<Mutex<HashMap<BucketId, Vec<u8>>>>;
+pub type BucketsGuard<'a> = MutexGuard<'a, HashMap<BucketId, Vec<u8>>>;
+
+// pub(crate) fn print_bucket_stats() {
+//     let buckets = get_buckets();
+//     let buckets = buckets.lock().unwrap();
+//     for (k, v) in buckets.iter() {
+//         println!("KEY {k:?} has {}", v.len());
+//     }
+// }
+
+// pub(crate) fn write_buckets() -> anyhow::Result<()> {
+//     let path = std::path::PathBuf::from("./logs");
+//     std::fs::create_dir_all(&path)?;
+//     let buckets = get_buckets();
+//     let buckets = buckets.lock().unwrap();
+//     for (k, v) in buckets.iter() {
+//         let filename = match k {
+//             None => format!("other.log"),
+//             Some(i) => format!("node-{i}.log"),
+//         };
+//         let path = path.join(filename);
+//         std::fs::write(path, v)?;
+//     }
+//     Ok(())
+// }
+
+pub(crate) fn try_init_global_subscriber() {
+    let print_layer = {
+        let env_filter = format!("{}=trace,iroh=info", env!("CARGO_CRATE_NAME"));
+        let print_filter = std::env::var("RUST_LOG").unwrap_or_else(|_| env_filter.to_string());
+        let print_filter = EnvFilter::new(print_filter);
+        tracing_subscriber::fmt::layer()
+            .with_writer(|| TestWriter)
+            .event_format(tracing_subscriber::fmt::format().with_line_number(true))
+            .with_level(true)
+            .with_filter(print_filter)
+    };
+
+    let buckets = get_buckets();
+    let bucket_writer = BucketWriter { buckets };
+    let json_layer = {
+        let filter = EnvFilter::new("debug");
+        tracing_subscriber::fmt::layer()
+            // .json()
+            .with_writer(bucket_writer)
+            .with_filter(filter)
+    };
+
+    let registry = tracing_subscriber::registry()
+        .with(SimNodeTracker)
+        .with(json_layer)
+        .with(print_layer);
+
+    registry.try_init().ok();
+}
+
+pub(crate) fn get_buckets() -> Buckets {
+    static BUCKETS: OnceLock<Buckets> = OnceLock::new();
+    BUCKETS.get_or_init(|| Default::default()).clone()
+}
+
+pub(crate) fn clear_bucket(idx: usize) -> Option<String> {
+    let buckets = get_buckets();
+    let mut buckets = buckets.lock().expect("poisoned");
+    let bucket = buckets.get_mut(&Some(idx))?;
+    let content = std::mem::take(bucket);
+    String::from_utf8(content).ok()
+}
+
+/// A tracing writer that interacts well with test output capture.
+///
+/// Using this writer will make sure that the output is captured normally and only printed
+/// when the test fails.
+#[derive(Debug)]
+struct TestWriter;
+
+impl std::io::Write for TestWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        print!(
+            "{}",
+            std::str::from_utf8(buf).expect("tried to log invalid UTF-8")
+        );
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        std::io::stdout().flush()
+    }
+}
+
+struct BucketWriter {
+    buckets: Buckets,
+}
+
+impl<'a> MakeWriter<'a> for BucketWriter {
+    type Writer = BucketGuardWriter<'a>;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        let state = CURRENT_SIM_NODE.with(|tls| tls.borrow().clone());
+        let node = state.map(|(_id, val)| val);
+        BucketGuardWriter(node, self.buckets.lock().unwrap())
+    }
+}
+
+pub struct BucketGuardWriter<'a>(BucketId, BucketsGuard<'a>);
+
+impl<'a> BucketGuardWriter<'a> {
+    fn get(&mut self) -> &mut dyn std::io::Write {
+        self.1.entry(self.0).or_default()
+    }
+}
+
+impl io::Write for BucketGuardWriter<'_> {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.get().write(buf)
+    }
+
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        self.get().flush()
+    }
+
+    #[inline]
+    fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
+        self.get().write_vectored(bufs)
+    }
+
+    #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.get().write_all(buf)
+    }
+
+    #[inline]
+    fn write_fmt(&mut self, fmt: std::fmt::Arguments<'_>) -> io::Result<()> {
+        self.get().write_fmt(fmt)
+    }
+}
+
+thread_local! {
+    static CURRENT_SIM_NODE: RefCell<Option<(Id, usize)>> = RefCell::new(None);
+}
+
+pub struct SimNodeTracker;
+
+impl<S> Layer<S> for SimNodeTracker
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        if attrs.metadata().name() == "sim-node" {
+            let span = ctx.span(id).unwrap();
+            let mut visitor = FindSimNode(None);
+            attrs.record(&mut visitor);
+            if let Some(node) = visitor.0 {
+                span.extensions_mut().insert(SimNode(node));
+            }
+        }
+    }
+
+    fn on_enter(&self, id: &Id, ctx: Context<'_, S>) {
+        if let Some(span) = ctx.span(id) {
+            if let Some(sim) = span.extensions().get::<SimNode>() {
+                CURRENT_SIM_NODE.with(|tls| *tls.borrow_mut() = Some((id.clone(), sim.0)));
+            } else {
+                let mut current = span.parent();
+                while let Some(span) = current {
+                    if let Some(sim) = span.extensions().get::<SimNode>() {
+                        CURRENT_SIM_NODE.with(|tls| *tls.borrow_mut() = Some((id.clone(), sim.0)));
+                        break;
+                    }
+                    current = span.parent();
+                }
+            }
+        }
+    }
+
+    fn on_exit(&self, id: &Id, _ctx: Context<'_, S>) {
+        // Clear the value on exit
+        CURRENT_SIM_NODE.with(|tls| {
+            let mut inner = tls.borrow_mut();
+            if let Some((last_id, _)) = inner.as_mut() {
+                if id == last_id {
+                    *inner = None;
+                }
+            }
+        });
+    }
+}
+
+struct FindSimNode(pub Option<usize>);
+
+impl tracing::field::Visit for FindSimNode {
+    fn record_u64(&mut self, field: &tracing::field::Field, val: u64) {
+        if field.name() == "idx" {
+            self.0 = Some(val as usize);
+        }
+    }
+
+    fn record_i64(&mut self, field: &tracing::field::Field, val: i64) {
+        if field.name() == "idx" && val >= 0 {
+            self.0 = Some(val as usize);
+        }
+    }
+
+    fn record_debug(&mut self, _field: &tracing::field::Field, _value: &dyn std::fmt::Debug) {}
+}
+
+#[derive(Debug)]
+struct SimNode(pub usize);


### PR DESCRIPTION
## Description

Adds a new trace protocol to send metrics and logs over quic irpc to a trace server.
Adds a simulation runner and proc macro to run simulation tests.

Supersedes #25 

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
