### PR TITLE
feat: support iroh v0.35

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,20 +3,6 @@
 version = 4
 
 [[package]]
-name = "acto"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a026259da4f1a13b4af60cda453c392de64c58c12d239c560923e0382f42f2b9"
-dependencies = [
- "parking_lot",
- "pin-project-lite",
- "rustc_version",
- "smol_str",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,6 +78,45 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
 
 [[package]]
 name = "async-compat"
@@ -210,6 +235,12 @@ name = "base64ct"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -343,6 +374,15 @@ dependencies = [
  "backtrace",
  "btparse",
  "termcolor",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -537,6 +577,20 @@ dependencies = [
  "der_derive",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -941,7 +995,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -1279,7 +1333,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -1456,7 +1510,7 @@ version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "cfg-if",
  "libc",
 ]
@@ -1491,6 +1545,68 @@ dependencies = [
 
 [[package]]
 name = "iroh"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ca758f4ce39ae3f07de922be6c73de6a48a07f39554e78b5745585652ce38f5"
+dependencies = [
+ "aead",
+ "anyhow",
+ "atomic-waker",
+ "backon",
+ "bytes",
+ "cfg_aliases",
+ "concurrent-queue",
+ "crypto_box",
+ "data-encoding",
+ "der",
+ "derive_more 1.0.0",
+ "ed25519-dalek",
+ "futures-buffered",
+ "futures-util",
+ "getrandom 0.3.3",
+ "hickory-resolver",
+ "http",
+ "igd-next",
+ "instant",
+ "iroh-base 0.35.0",
+ "iroh-metrics 0.34.0",
+ "iroh-quinn 0.13.0",
+ "iroh-quinn-proto",
+ "iroh-quinn-udp",
+ "iroh-relay 0.35.0",
+ "n0-future",
+ "netdev 0.31.0",
+ "netwatch 0.5.0",
+ "pin-project",
+ "pkarr",
+ "portmapper 0.5.0",
+ "rand 0.8.5",
+ "rcgen",
+ "reqwest",
+ "ring",
+ "rustls",
+ "rustls-webpki 0.102.8",
+ "serde",
+ "smallvec",
+ "spki",
+ "strum 0.26.3",
+ "stun-rs",
+ "surge-ping",
+ "thiserror 2.0.12",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "url",
+ "wasm-bindgen-futures",
+ "webpki-roots 0.26.11",
+ "x509-parser",
+ "z32",
+]
+
+[[package]]
+name = "iroh"
 version = "0.91.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef05c956df0788a649d65c33fdbbb8fc4442d7716af3d67a1bd6d00a9ee56ead"
@@ -1511,35 +1627,34 @@ dependencies = [
  "http",
  "igd-next",
  "instant",
- "iroh-base",
- "iroh-metrics",
- "iroh-quinn",
+ "iroh-base 0.91.0",
+ "iroh-metrics 0.35.0",
+ "iroh-quinn 0.14.0",
  "iroh-quinn-proto",
  "iroh-quinn-udp",
- "iroh-relay",
+ "iroh-relay 0.91.0",
  "n0-future",
  "n0-snafu",
  "n0-watcher",
  "nested_enum_utils",
- "netdev",
- "netwatch",
+ "netdev 0.36.0",
+ "netwatch 0.8.0",
  "pin-project",
  "pkarr",
- "portmapper",
+ "portmapper 0.8.0",
  "rand 0.8.5",
  "reqwest",
  "ring",
  "rustls",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.4",
  "serde",
  "smallvec",
  "snafu",
  "spki",
- "strum",
+ "strum 0.27.2",
  "stun-rs",
  "surge-ping",
- "swarm-discovery",
  "time",
  "tokio",
  "tokio-stream",
@@ -1549,6 +1664,22 @@ dependencies = [
  "wasm-bindgen-futures",
  "webpki-roots 0.26.11",
  "z32",
+]
+
+[[package]]
+name = "iroh-base"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91ac4aaab68153d726c4e6b39c30f9f9253743f0e25664e52f4caeb46f48d11"
+dependencies = [
+ "curve25519-dalek",
+ "data-encoding",
+ "derive_more 1.0.0",
+ "ed25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "thiserror 2.0.12",
+ "url",
 ]
 
 [[package]]
@@ -1567,6 +1698,19 @@ dependencies = [
  "serde",
  "snafu",
  "url",
+]
+
+[[package]]
+name = "iroh-metrics"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f70466f14caff7420a14373676947e25e2917af6a5b1bec45825beb2bf1eb6a7"
+dependencies = [
+ "iroh-metrics-derive",
+ "itoa",
+ "serde",
+ "snafu",
+ "tracing",
 ]
 
 [[package]]
@@ -1602,11 +1746,11 @@ dependencies = [
  "anyhow",
  "derive_more 2.0.1",
  "ed25519-dalek",
- "iroh",
- "iroh-metrics",
+ "iroh 0.35.0",
+ "iroh 0.91.0",
+ "iroh-metrics 0.35.0",
  "iroh-n0des-macro",
- "iroh-ping",
- "iroh-quinn",
+ "iroh-quinn 0.14.0",
  "irpc",
  "irpc-iroh",
  "n0-future",
@@ -1615,7 +1759,7 @@ dependencies = [
  "serde",
  "serde_json",
  "ssh-key",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.12",
  "time",
  "tokio",
@@ -1634,14 +1778,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "iroh-ping"
-version = "0.2.0"
-source = "git+https://github.com/n0-computer/iroh-ping?branch=main#f3441c14b12a69f3c636863317438cbc80a403fe"
+name = "iroh-quinn"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76c6245c9ed906506ab9185e8d7f64857129aee4f935e899f398a3bd3b70338d"
 dependencies = [
- "anyhow",
- "iroh",
- "iroh-metrics",
- "n0-snafu",
+ "bytes",
+ "cfg_aliases",
+ "iroh-quinn-proto",
+ "iroh-quinn-udp",
+ "pin-project-lite",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.5.10",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+ "web-time",
 ]
 
 [[package]]
@@ -1700,6 +1853,53 @@ dependencies = [
 
 [[package]]
 name = "iroh-relay"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c63f122cdfaa4b4e0e7d6d3921d2b878f42a0c6d3ee5a29456dc3f5ab5ec931f"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "cfg_aliases",
+ "data-encoding",
+ "derive_more 1.0.0",
+ "getrandom 0.3.3",
+ "hickory-resolver",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "iroh-base 0.35.0",
+ "iroh-metrics 0.34.0",
+ "iroh-quinn 0.13.0",
+ "iroh-quinn-proto",
+ "lru 0.12.5",
+ "n0-future",
+ "num_enum",
+ "pin-project",
+ "pkarr",
+ "postcard",
+ "rand 0.8.5",
+ "reqwest",
+ "rustls",
+ "rustls-webpki 0.102.8",
+ "serde",
+ "sha1",
+ "strum 0.26.3",
+ "stun-rs",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tokio-websockets 0.11.4",
+ "tracing",
+ "url",
+ "webpki-roots 0.26.11",
+ "ws_stream_wasm",
+ "z32",
+]
+
+[[package]]
+name = "iroh-relay"
 version = "0.91.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49596b5079817d0904fe4985307f532a4e23a33eb494bd680baaf2743f0c456b"
@@ -1715,11 +1915,11 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
- "iroh-base",
- "iroh-metrics",
- "iroh-quinn",
+ "iroh-base 0.91.0",
+ "iroh-metrics 0.35.0",
+ "iroh-quinn 0.14.0",
  "iroh-quinn-proto",
- "lru",
+ "lru 0.13.0",
  "n0-future",
  "n0-snafu",
  "nested_enum_utils",
@@ -1731,16 +1931,16 @@ dependencies = [
  "reqwest",
  "rustls",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.4",
  "serde",
  "serde_bytes",
  "sha1",
  "snafu",
- "strum",
+ "strum 0.27.2",
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tokio-websockets",
+ "tokio-websockets 0.12.0",
  "tracing",
  "url",
  "webpki-roots 0.26.11",
@@ -1757,7 +1957,7 @@ dependencies = [
  "anyhow",
  "futures-buffered",
  "futures-util",
- "iroh-quinn",
+ "iroh-quinn 0.14.0",
  "irpc-derive",
  "n0-future",
  "postcard",
@@ -1790,7 +1990,7 @@ checksum = "f5926531af491c6962db4d79f43ea219404cb800889922a728b1d3b92f887eda"
 dependencies = [
  "anyhow",
  "getrandom 0.3.3",
- "iroh",
+ "iroh 0.91.0",
  "irpc",
  "n0-future",
  "postcard",
@@ -1879,6 +2079,15 @@ dependencies = [
 
 [[package]]
 name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
+name = "lru"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
@@ -1912,6 +2121,12 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2011,6 +2226,23 @@ dependencies = [
 
 [[package]]
 name = "netdev"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f901362e84cd407be6f8cd9d3a46bccf09136b095792785401ea7d283c79b91d"
+dependencies = [
+ "dlopen2",
+ "ipnet",
+ "libc",
+ "netlink-packet-core",
+ "netlink-packet-route 0.17.1",
+ "netlink-sys",
+ "once_cell",
+ "system-configuration",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "netdev"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "862209dce034f82a44c95ce2b5183730d616f2a68746b9c1959aa2572e77c0a1"
@@ -2039,12 +2271,41 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-route"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053998cea5a306971f88580d0829e90f270f940befd7cf928da179d4187a5a66"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "byteorder",
+ "libc",
+ "netlink-packet-core",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-route"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0e7987b28514adf555dc1f9a5c30dfc3e50750bbaffb1aec41ca7b23dcd8e4"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.9.1",
+ "byteorder",
+ "libc",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0800eae8638a299eaa67476e1c6b6692922273e0f7939fd188fc861c837b9cd2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.9.1",
  "byteorder",
  "libc",
  "log",
@@ -2059,7 +2320,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56d83370a96813d7c977f8b63054f1162df6e5784f1c598d689236564fb5a6f2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.9.1",
  "byteorder",
  "libc",
  "log",
@@ -2108,6 +2369,39 @@ dependencies = [
 
 [[package]]
 name = "netwatch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eeaa5f7505c93c5a9b35ba84fd21fb8aa3f24678c76acfe8716af7862fb07a"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "cfg_aliases",
+ "derive_more 1.0.0",
+ "iroh-quinn-udp",
+ "js-sys",
+ "libc",
+ "n0-future",
+ "nested_enum_utils",
+ "netdev 0.31.0",
+ "netlink-packet-core",
+ "netlink-packet-route 0.23.0",
+ "netlink-proto",
+ "netlink-sys",
+ "serde",
+ "snafu",
+ "socket2 0.5.10",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "web-sys",
+ "windows 0.59.0",
+ "windows-result",
+ "wmi 0.14.5",
+]
+
+[[package]]
+name = "netwatch"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8901dbb408894af3df3fc51420ba0c6faf3a7d896077b797c39b7001e2f787bd"
@@ -2122,7 +2416,7 @@ dependencies = [
  "n0-future",
  "n0-watcher",
  "nested_enum_utils",
- "netdev",
+ "netdev 0.36.0",
  "netlink-packet-core",
  "netlink-packet-route 0.24.0",
  "netlink-proto",
@@ -2136,9 +2430,9 @@ dependencies = [
  "tokio-util",
  "tracing",
  "web-sys",
- "windows",
+ "windows 0.61.3",
  "windows-result",
- "wmi",
+ "wmi 0.17.2",
 ]
 
 [[package]]
@@ -2146,6 +2440,16 @@ name = "no-std-net"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "ntimestamp"
@@ -2170,6 +2474,16 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -2254,6 +2568,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -2479,7 +2802,7 @@ dependencies = [
  "futures-lite",
  "getrandom 0.2.16",
  "log",
- "lru",
+ "lru 0.13.0",
  "ntimestamp",
  "reqwest",
  "self_cell",
@@ -2575,6 +2898,37 @@ checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "portmapper"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d6db66007eac4a0ec8331d0d20c734bd64f6445d64bbaf0d0a27fea7a054e36"
+dependencies = [
+ "base64",
+ "bytes",
+ "derive_more 1.0.0",
+ "futures-lite",
+ "futures-util",
+ "hyper-util",
+ "igd-next",
+ "iroh-metrics 0.34.0",
+ "libc",
+ "nested_enum_utils",
+ "netwatch 0.5.0",
+ "num_enum",
+ "rand 0.8.5",
+ "serde",
+ "smallvec",
+ "snafu",
+ "socket2 0.5.10",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "portmapper"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f1975debe62a70557e42b9ff9466e4890cf9d3d156d296408a711f1c5f642b"
@@ -2586,10 +2940,10 @@ dependencies = [
  "futures-util",
  "hyper-util",
  "igd-next",
- "iroh-metrics",
+ "iroh-metrics 0.35.0",
  "libc",
  "nested_enum_utils",
- "netwatch",
+ "netwatch 0.8.0",
  "num_enum",
  "rand 0.9.2",
  "serde",
@@ -2888,7 +3242,7 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8af0dde094006011e6a740d4879319439489813bd0bcdc7d821beaeeff48ec"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -3055,6 +3409,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3064,7 +3427,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.4",
  "subtle",
  "zeroize",
 ]
@@ -3077,6 +3440,17 @@ checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
  "web-time",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -3292,7 +3666,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dee851d0e5e7af3721faea1843e8015e820a234f81fda3dea9247e15bac9a86a"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -3306,12 +3680,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "smol_str"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad6c857cbab2627dcf01ec85a623ca4e7dcb5691cbaa3d7fb7653671f0d09c9"
 
 [[package]]
 name = "snafu"
@@ -3424,11 +3792,33 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3490,21 +3880,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "swarm-discovery"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eae338a4551897c6a50fa2c041c4b75f578962d9fca8adb828cf81f7158740f"
-dependencies = [
- "acto",
- "hickory-proto",
- "rand 0.9.2",
- "socket2 0.5.10",
- "thiserror 2.0.12",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3552,7 +3927,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -3757,6 +4132,28 @@ dependencies = [
 
 [[package]]
 name = "tokio-websockets"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fcaf159b4e7a376b05b5bfd77bfd38f3324f5fce751b4213bfc7eaa47affb4e"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "getrandom 0.3.3",
+ "http",
+ "httparse",
+ "rand 0.9.2",
+ "ring",
+ "rustls-pki-types",
+ "simdutf8",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+]
+
+[[package]]
+name = "tokio-websockets"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f29ba084eb43becc9864ba514b4a64f5f65b82f9a6ffbafa5436c1c80605f03"
@@ -3815,7 +4212,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "bytes",
  "futures-util",
  "http",
@@ -4215,12 +4612,22 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f919aee0a93304be7f62e8e5027811bbba96bcb1de84d6618be56e43f8a32a1"
+dependencies = [
+ "windows-core 0.59.0",
+ "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core",
+ "windows-core 0.61.2",
  "windows-future",
  "windows-link",
  "windows-numerics",
@@ -4232,7 +4639,20 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "810ce18ed2112484b0d4e15d022e5f598113e220c53e373fb31e67e21670c1ce"
+dependencies = [
+ "windows-implement 0.59.0",
+ "windows-interface",
+ "windows-result",
+ "windows-strings 0.3.1",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -4241,11 +4661,11 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
+ "windows-implement 0.60.0",
  "windows-interface",
  "windows-link",
  "windows-result",
- "windows-strings",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -4254,9 +4674,20 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link",
  "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83577b051e2f49a058c308f17f273b570a6a758386fc291b5f6a934dd84e48c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4293,7 +4724,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link",
 ]
 
@@ -4302,6 +4733,15 @@ name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
  "windows-link",
 ]
@@ -4366,11 +4806,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -4395,6 +4852,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4405,6 +4868,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4419,10 +4888,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4437,6 +4918,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4447,6 +4934,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4461,6 +4954,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4471,6 +4970,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
@@ -4497,7 +5002,22 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
+]
+
+[[package]]
+name = "wmi"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7787dacdd8e71cbc104658aade4009300777f9b5fda6a75f19145fedb8a18e71"
+dependencies = [
+ "chrono",
+ "futures",
+ "log",
+ "serde",
+ "thiserror 2.0.12",
+ "windows 0.59.0",
+ "windows-core 0.59.0",
 ]
 
 [[package]]
@@ -4511,8 +5031,8 @@ dependencies = [
  "log",
  "serde",
  "thiserror 2.0.12",
- "windows",
- "windows-core",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -4538,6 +5058,23 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,9 @@ anyhow = "1.0.95"
 derive_more = { version = "2.0.1", features = ["display", "from"] }
 ed25519-dalek = "2.1.1"
 irpc = "0.7.0"
-irpc-iroh = "0.7.0"
-iroh = { version = "0.91", features = ["discovery-local-network"] }
+irpc-iroh = { version = "0.7.0", optional = true }
+iroh = { version = "0.91", optional = true }
+iroh_035 = { package = "iroh", version = "0.35", optional = true }
 iroh-n0des-macro = { version = "0.2.0", path = "iroh-n0des-macro" }
 iroh-metrics = "0.35"
 n0-future = "0.1.2"
@@ -38,8 +39,15 @@ tracing-subscriber = { version = "0.3.19", features = [
 ] }
 serde_json = "1.0.140"
 
-[dev-dependencies]
-iroh-ping = { git = "https://github.com/n0-computer/iroh-ping", branch = "main" }
-
 [workspace]
 members = ["iroh-n0des-macro"]
+
+[features]
+default = ["iroh_main"]
+iroh_main = ["dep:iroh", "dep:irpc-iroh"]
+iroh_v035 = ["dep:iroh_035"]
+
+[[bin]]
+name = "iroh-n0des"
+path = "src/main.rs"
+required-features = ["iroh_main"]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An iroh protocol to interact with n0des, using iroh itself.
 
+## Feature flags
+
+By default, `iroh-n0des` depends on `iroh` v0.90. When the `iroh_v035` feature flag is enabled, the `simulation` module uses `iroh` v0.35 instead. When default features are disabled, all features that depend on `iroh` v0.90 are disabled.
+
 
 ## License
 

--- a/deny.toml
+++ b/deny.toml
@@ -31,6 +31,4 @@ ignore = [
 ]
 
 [sources]
-allow-git = [
-    "https://github.com/n0-computer/iroh-ping",
-]
+allow-git = []

--- a/src/client.rs
+++ b/src/client.rs
@@ -129,7 +129,7 @@ impl From<irpc::Error> for BuildError {
     fn from(value: irpc::Error) -> Self {
         match value {
             irpc::Error::Request(irpc::RequestError::Connection(
-                iroh::endpoint::ConnectionError::ApplicationClosed(frame),
+                crate::iroh::endpoint::ConnectionError::ApplicationClosed(frame),
             )) if frame.error_code == 401u32.into() => Self::Unauthorized,
             value => Self::Rpc(value),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,10 @@
+#[cfg(feature = "iroh_main")]
 mod client;
 mod n0des;
 
+#[cfg(feature = "iroh_main")]
 pub mod caps;
+#[cfg(feature = "iroh_main")]
 pub mod protocol;
 pub mod simulation;
 
@@ -12,8 +15,26 @@ extern crate self as iroh_n0des;
 
 pub use iroh_metrics::Registry;
 
+#[cfg(feature = "iroh_v035")]
+pub use iroh_035 as iroh;
+
+#[cfg(feature = "iroh_main")]
+pub use iroh;
+
+pub use anyhow;
+
+#[cfg(all(feature = "iroh_v035", feature = "iroh_main"))]
+compile_error!(
+    "Features 'iroh_v035' and 'iroh_main' cannot be enabled at the same time. Choose only one."
+);
+
+#[cfg(not(any(feature = "iroh_v035", feature = "iroh_main")))]
+compile_error!("You must enable exactly one of the features: 'iroh_v035' or 'iroh_main'.");
+
+#[cfg(feature = "iroh_main")]
 pub use self::{
     client::{Client, ClientBuilder},
-    n0des::N0de,
     protocol::ALPN,
 };
+
+pub use self::n0des::N0de;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,21 +15,17 @@ pub use iroh_n0des_macro::sim;
 // This lets us use the derive metrics in the lib tests within this crate.
 extern crate self as iroh_n0des;
 
-pub use iroh_metrics::Registry;
-
-#[cfg(feature = "iroh_v035")]
-pub use iroh_035 as iroh;
-
+pub use anyhow;
 #[cfg(all(feature = "iroh_main", not(feature = "iroh_v035")))]
 pub use iroh;
+#[cfg(feature = "iroh_v035")]
+pub use iroh_035 as iroh;
+pub use iroh_metrics::Registry;
 
-pub use anyhow;
-
+#[cfg(any(feature = "iroh_v035", feature = "iroh_main"))]
+pub use self::n0des::N0de;
 #[cfg(feature = "iroh_main")]
 pub use self::{
     client::{Client, ClientBuilder},
     protocol::ALPN,
 };
-
-#[cfg(any(feature = "iroh_v035", feature = "iroh_main"))]
-pub use self::n0des::N0de;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,13 @@
 #[cfg(feature = "iroh_main")]
 mod client;
+#[cfg(any(feature = "iroh_v035", feature = "iroh_main"))]
 mod n0des;
 
 #[cfg(feature = "iroh_main")]
 pub mod caps;
 #[cfg(feature = "iroh_main")]
 pub mod protocol;
+#[cfg(any(feature = "iroh_v035", feature = "iroh_main"))]
 pub mod simulation;
 
 pub use iroh_n0des_macro::sim;
@@ -18,18 +20,10 @@ pub use iroh_metrics::Registry;
 #[cfg(feature = "iroh_v035")]
 pub use iroh_035 as iroh;
 
-#[cfg(feature = "iroh_main")]
+#[cfg(all(feature = "iroh_main", not(feature = "iroh_v035")))]
 pub use iroh;
 
 pub use anyhow;
-
-#[cfg(all(feature = "iroh_v035", feature = "iroh_main"))]
-compile_error!(
-    "Features 'iroh_v035' and 'iroh_main' cannot be enabled at the same time. Choose only one."
-);
-
-#[cfg(not(any(feature = "iroh_v035", feature = "iroh_main")))]
-compile_error!("You must enable exactly one of the features: 'iroh_v035' or 'iroh_main'.");
 
 #[cfg(feature = "iroh_main")]
 pub use self::{
@@ -37,4 +31,5 @@ pub use self::{
     protocol::ALPN,
 };
 
+#[cfg(any(feature = "iroh_v035", feature = "iroh_main"))]
 pub use self::n0des::N0de;

--- a/src/n0des.rs
+++ b/src/n0des.rs
@@ -1,8 +1,9 @@
 use std::future::Future;
 
 use anyhow::Result;
-use iroh::Endpoint;
 use iroh_metrics::Registry;
+
+use crate::iroh::Endpoint;
 
 /// A trait for nodes that can be spawned and shut down
 pub trait N0de: 'static + Send + Sync {

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -17,7 +17,7 @@ use tracing::{Instrument, Span, error, error_span};
 
 use crate::iroh::{Endpoint, NodeAddr, NodeId};
 
-#[cfg(feature = "iroh_main")]
+#[cfg(all(feature = "iroh_main", not(feature = "iroh_v035")))]
 use iroh::Watcher;
 
 use crate::n0des::N0de;

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -8,6 +8,8 @@ use std::{
 };
 
 use anyhow::{Context as _, Result};
+#[cfg(all(feature = "iroh_main", not(feature = "iroh_v035")))]
+use iroh::Watcher;
 use iroh_metrics::{Registry, encoding::Encoder};
 use n0_future::{FuturesUnordered, TryStreamExt};
 use proto::{ActiveTrace, NodeInfo, NodeInfoWithAddr, ScopeInfo, TraceClient, TraceInfo};
@@ -15,12 +17,10 @@ use tokio::sync::Semaphore;
 use trace::submit_logs;
 use tracing::{Instrument, Span, error, error_span};
 
-use crate::iroh::{Endpoint, NodeAddr, NodeId};
-
-#[cfg(all(feature = "iroh_main", not(feature = "iroh_v035")))]
-use iroh::Watcher;
-
-use crate::n0des::N0de;
+use crate::{
+    iroh::{Endpoint, NodeAddr, NodeId},
+    n0des::N0de,
+};
 
 pub mod events;
 pub mod proto;
@@ -521,17 +521,17 @@ where
 #[cfg(test)]
 mod tests {
 
+    use std::sync::Arc;
+
     use iroh_metrics::Counter;
     use rand::seq::IteratorRandom;
-    use std::sync::Arc;
     use tracing::{debug, instrument};
 
+    use super::*;
     use crate::iroh::{
         endpoint::Connection,
         protocol::{ProtocolHandler, Router},
     };
-
-    use super::*;
 
     const ALPN: &[u8] = b"iroh-n0des/test/ping/0";
 

--- a/src/simulation/events.rs
+++ b/src/simulation/events.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, fmt};
 
-use iroh::NodeId;
+use crate::iroh::NodeId;
 
 pub struct EventId<'a, T>(Option<&'a T>);
 

--- a/src/simulation/proto.rs
+++ b/src/simulation/proto.rs
@@ -1,6 +1,5 @@
 use std::net::SocketAddr;
 
-use crate::iroh::{NodeAddr, NodeId};
 use anyhow::Result;
 use iroh_metrics::encoding::Update;
 use irpc::{channel::oneshot, rpc_requests, util::make_insecure_client_endpoint};
@@ -12,6 +11,7 @@ use tracing::debug;
 use uuid::Uuid;
 
 use super::{ENV_TRACE_SERVER, ENV_TRACE_SESSION_ID};
+use crate::iroh::{NodeAddr, NodeId};
 
 pub const ALPN: &[u8] = b"/iroh/n0des-sim/1";
 

--- a/src/simulation/proto.rs
+++ b/src/simulation/proto.rs
@@ -1,9 +1,10 @@
 use std::net::SocketAddr;
 
+use crate::iroh::{NodeAddr, NodeId};
 use anyhow::Result;
-use iroh::{Endpoint, NodeAddr, NodeId};
 use iroh_metrics::encoding::Update;
 use irpc::{channel::oneshot, rpc_requests, util::make_insecure_client_endpoint};
+#[cfg(feature = "iroh_main")]
 use irpc_iroh::IrohRemoteConnection;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime as DateTime;
@@ -240,13 +241,15 @@ impl TraceClient {
         Self { client, session_id }
     }
 
+    #[cfg(feature = "iroh_main")]
     pub async fn connect_iroh(remote: NodeId, session_id: Uuid) -> Result<Self> {
-        let endpoint = Endpoint::builder().discovery_local_network().bind().await?;
+        let endpoint = iroh::Endpoint::builder().bind().await?;
         Ok(Self::connect_iroh_endpoint(endpoint, remote, session_id))
     }
 
+    #[cfg(feature = "iroh_main")]
     pub fn connect_iroh_endpoint(
-        endpoint: Endpoint,
+        endpoint: iroh::Endpoint,
         remote: impl Into<NodeAddr>,
         session_id: Uuid,
     ) -> Self {

--- a/src/simulation/proto.rs
+++ b/src/simulation/proto.rs
@@ -242,7 +242,7 @@ impl TraceClient {
     }
 
     #[cfg(feature = "iroh_main")]
-    pub async fn connect_iroh(remote: NodeId, session_id: Uuid) -> Result<Self> {
+    pub async fn connect_iroh(remote: iroh::NodeId, session_id: Uuid) -> Result<Self> {
         let endpoint = iroh::Endpoint::builder().bind().await?;
         Ok(Self::connect_iroh_endpoint(endpoint, remote, session_id))
     }
@@ -250,7 +250,7 @@ impl TraceClient {
     #[cfg(feature = "iroh_main")]
     pub fn connect_iroh_endpoint(
         endpoint: iroh::Endpoint,
-        remote: impl Into<NodeAddr>,
+        remote: impl Into<iroh::NodeAddr>,
         session_id: Uuid,
     ) -> Self {
         let conn = IrohRemoteConnection::new(endpoint, remote.into(), ALPN.to_vec());


### PR DESCRIPTION
## Description

* Adds an optional feature "iroh_v035" which switches the iroh version to iroh 0.35 in the simulation runner. 
* Adds an on-by-default feature "iroh_main" to use current iroh (0.91)
* The two features are mutually exclusive (which is a bit of a bad practice due to feature unification, but fine for this quite far downstream usage)
* The non-simulation features of the crate (client to talk to n0des service) are disabled if "iroh_main" is not enabled

Use with
```
iroh_nodes = { git = "https://github.com/n0-computer/iroh-nodes", branch ="Frando/iroh35", default-features = false, features = ["iroh_v035"] }
```

### Open issues

[ ] Support metrics (atm endpoint metrics tracking to the trace server is disabled if using 0.35), need to add support for tracking metrics from iroh-metrics 0.34 to iroh-metrics 0.35.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
