### PR TITLE
fix: don't close traces in init-only mode

### DIFF
--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -342,7 +342,7 @@ impl<T: Node + Sized> DynNode for T {
 /// before building the final simulation.
 pub struct Builder<D = ()> {
     setup_fn: BoxedSetupFn<D>,
-    spawners: Vec<(u32, ErasedNodeBuilder<D>)>,
+    node_builders: Vec<(u32, ErasedNodeBuilder<D>)>,
     rounds: u32,
 }
 
@@ -612,7 +612,7 @@ impl Builder<()> {
     pub fn new() -> Builder<()> {
         let setup_fn: BoxedSetupFn<()> = Box::new(move || Box::pin(async move { Ok(()) }));
         Builder {
-            spawners: Vec::new(),
+            node_builders: Vec::new(),
             setup_fn,
             rounds: 0,
         }
@@ -638,7 +638,7 @@ impl<D: SetupData> Builder<D> {
     {
         let setup_fn: BoxedSetupFn<D> = Box::new(move || Box::pin(setup_fn()));
         Builder {
-            spawners: Vec::new(),
+            node_builders: Vec::new(),
             setup_fn,
             rounds: 0,
         }
@@ -663,7 +663,7 @@ impl<D: SetupData> Builder<D> {
         node_builder: impl Into<NodeBuilder<N, D>>,
     ) -> Self {
         let node_builder = node_builder.into();
-        self.spawners.push((node_count, node_builder.erase()));
+        self.node_builders.push((node_count, node_builder.erase()));
         self
     }
 
@@ -686,7 +686,11 @@ impl<D: SetupData> Builder<D> {
         {
             let setup_data = (self.setup_fn)().await?;
             let encoded_setup_data = Bytes::from(postcard::to_stdvec(&setup_data)?);
-            let node_count = self.spawners.iter().map(|(count, _spawner)| count).sum();
+            let node_count = self
+                .node_builders
+                .iter()
+                .map(|(count, _spawner)| count)
+                .sum();
             let trace_id = client
                 .init_trace(
                     TraceInfo {
@@ -714,18 +718,18 @@ impl<D: SetupData> Builder<D> {
             (trace_id, setup_data)
         };
 
-        let mut spawners = self
-            .spawners
+        let mut node_builders = self
+            .node_builders
             .into_iter()
             .flat_map(|(count, spawner)| (0..count).map(move |_| spawner.clone()))
             .enumerate()
             .map(|(idx, spawner)| (idx as u32, spawner));
 
-        let spawners: Vec<_> = match run_mode {
+        let node_builders: Vec<_> = match run_mode {
             RunMode::InitOnly => vec![],
-            RunMode::Integrated => spawners.collect(),
+            RunMode::Integrated => node_builders.collect(),
             RunMode::Isolated(idx) => vec![
-                spawners
+                node_builders
                     .nth(idx as usize)
                     .context("invalid isolated index")?,
             ],
@@ -734,7 +738,7 @@ impl<D: SetupData> Builder<D> {
         Ok(Simulation {
             run_mode,
             max_rounds: self.rounds,
-            node_builders: spawners,
+            node_builders,
             client,
             trace_id,
             setup_data,
@@ -772,11 +776,13 @@ impl<D: SetupData> Simulation<D> {
             let cancel_token = cancel_token.clone();
             let client = self.client.clone();
             let trace_id = self.trace_id;
-            let scope = match self.run_mode {
-                RunMode::Isolated(idx) => Scope::Isolated(idx),
-                _ => Scope::Integrated,
-            };
             tokio::task::spawn(async move {
+                let scope = match self.run_mode {
+                    RunMode::Isolated(idx) => Scope::Isolated(idx),
+                    RunMode::Integrated => Scope::Integrated,
+                    // Do not push logs for init-only runs.
+                    RunMode::InitOnly => return,
+                };
                 loop {
                     let _ = cancel_token
                         .run_until_cancelled(tokio::time::sleep(Duration::from_secs(1)))
@@ -816,7 +822,7 @@ impl<D: SetupData> Simulation<D> {
         cancel_token.cancel();
         logs_task.await?;
 
-        if matches!(self.run_mode, RunMode::InitOnly | RunMode::Integrated) {
+        if matches!(self.run_mode, RunMode::Integrated) {
             self.client
                 .close_trace(self.trace_id, to_str_err(&result))
                 .await?;

--- a/src/simulation/proto.rs
+++ b/src/simulation/proto.rs
@@ -348,7 +348,7 @@ impl TraceClient {
         Ok(())
     }
 
-    pub async fn status(&self, session_id: Uuid) -> Result<Option<GetSessionResponse>> {
+    pub async fn get_session(&self, session_id: Uuid) -> Result<Option<GetSessionResponse>> {
         let res = self.client.rpc(GetSession { session_id }).await??;
         Ok(res)
     }


### PR DESCRIPTION
## Description

`isolated` mode is broken after #29 because we called `close_trace` even when in InitOnly mode. this is wrong of course, close should only be called in integrated mode at the end. When in isolated or init-only mode, close should not be called at all, it is called by the `n0des` cli command after all isolated nodes finished.

Longer explanation what `InitOnly` means (copied from discord):

when running n0des run-sim --isolated,  cargo test first invoked with N0DES_INIT_ONLY=1.  when this is found, RunMode::InitOnly is passed to the simulation builder/runner, which then only sends the InitTrace command to the trace server, which contains the trace names, expected number of nodes, and the setup data. it then exits without running any simulations. the n0des command then gets this data from the trace server, to know how many instances should be launched. these then get an N0DES_ISOLATED_IDX var, which sets RunMode::Isolated(idx), which makes the runner call GetTrace to the server to get the setup data, and then run only a single node. 
(if neither env vars are set, then RunMode::Integrated is invoked, which calls both InitTrace and then runs all nodes in-process)

unrelated change: renamed `spawners` to `node_builders`  for consistency.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
