### PR TITLE
fix: Hotfix sending `PutLogs` messages greater than `MAX_MESSAGE_SIZE`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4422,9 +4422,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.5"
+version = "2.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec961601b32b6f5d14ae8dabd35ff2ff2e2c6cb4c0e6641845ff105abe96d958"
+checksum = "137a3c834eaf7139b73688502f3f1141a0337c5d8e4d9b536f9b8c796e26a7c4"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -881,9 +881,19 @@ fn spawn_logs_task(
             let _ = cancel_token
                 .run_until_cancelled(tokio::time::sleep(Duration::from_secs(1)))
                 .await;
-            let lines = self::trace::get_logs().await;
-            if client.put_logs(trace_id, scope, lines).await.is_err() {
-                break;
+            let lines = self::trace::get_logs();
+            if lines.is_empty() {
+                continue;
+            }
+            // 500 chosen so that we stay below ~16MB of logs (irpc's MAX_MESSAGE_SIZE limit).
+            // This gives us ~32KB per log line on average.
+            for lines_chunk in lines.chunks(500) {
+                if let Err(e) = client.put_logs(trace_id, scope, lines_chunk.to_vec()).await {
+                    eprintln!(
+                        "warning: failed to submit logs due to error, stopping log submission now: {e:?}"
+                    );
+                    break;
+                }
             }
             if cancel_token.is_cancelled() {
                 break;

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -878,9 +878,13 @@ fn spawn_logs_task(
 ) -> tokio::task::JoinHandle<()> {
     tokio::task::spawn(async move {
         loop {
-            let _ = cancel_token
+            if cancel_token
                 .run_until_cancelled(tokio::time::sleep(Duration::from_secs(1)))
-                .await;
+                .await
+                .is_none()
+            {
+                break;
+            }
             let lines = self::trace::get_logs();
             if lines.is_empty() {
                 continue;

--- a/src/simulation/trace.rs
+++ b/src/simulation/trace.rs
@@ -63,9 +63,9 @@ pub async fn submit_logs(client: &ActiveTrace) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub async fn get_logs() -> Vec<String> {
+pub fn get_logs() -> Vec<String> {
     let writer = global_writer();
-    writer.get().await
+    writer.get()
 }
 
 /// A tracing writer that interacts well with test output capture.
@@ -106,7 +106,7 @@ impl LineWriter {
         self.buf.lock().expect("lock poisoned").clear();
     }
 
-    pub async fn get(&self) -> Vec<String> {
+    pub fn get(&self) -> Vec<String> {
         let mut buf = self.buf.lock().expect("lock poisoned");
         let lines = buf
             .lines()
@@ -123,7 +123,7 @@ impl LineWriter {
     }
 
     pub async fn submit(&self, client: &ActiveTrace) -> anyhow::Result<()> {
-        let lines = self.get().await;
+        let lines = self.get();
         client.put_logs(lines).await?;
         Ok(())
     }


### PR DESCRIPTION
## Description

Previously we would sever the connection to the trace server when one node produced more than ~16MB of logs in 1s.
(Our polling interval is 1s, and irpc's `MAX_MESSAGE_SIZE` is 1024² * 16.)

## Notes & open questions

I'm not trying to chunk messages into `MAX_MESSAGE_SIZE` pieces here, I don't really think there's any point in doing that.
We already can't compute the exact size that a message will have in advance without already serializing it, and I don't want to go through all lines to tally the total.
There's a longer-standing TODO to switch this to a `client_streaming` call instead.

## Change checklist

- [x] Self-review.
