### PR TITLE
feat: constructors for trace layer and client

### DIFF
--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -926,10 +926,10 @@ where
         .with_context(|| format!("simulation builder function `{name}` failed"))?
         .build(name)
         .await
-        .with_context(|| format!("simulation `{name}` failed to build"))?
+        .with_context(|| format!("simulation `{name}` failed to start"))?
         .run()
         .await
-        .with_context(|| format!("simulation `{name}` failed to run"));
+        .with_context(|| format!("simulation `{name}` failed to complete"));
 
     match &result {
         Ok(()) => eprintln!("simulation `{name}` passed"),

--- a/src/simulation/proto.rs
+++ b/src/simulation/proto.rs
@@ -266,6 +266,10 @@ impl TraceClient {
         }
     }
 
+    pub fn new(client: irpc::Client<TraceProtocol>, session_id: Uuid) -> Self {
+        Self { client, session_id }
+    }
+
     pub fn connect_quinn_insecure(remote: SocketAddr, session_id: Uuid) -> Result<Self> {
         let addr_localhost = "127.0.0.1:0".parse().unwrap();
         let endpoint = make_insecure_client_endpoint(addr_localhost)?;

--- a/src/simulation/trace.rs
+++ b/src/simulation/trace.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use tracing_subscriber::{
-    EnvFilter, Layer,
+    EnvFilter, Layer, Registry,
     fmt::{MakeWriter, writer::MutexGuardWriter},
     layer::SubscriberExt,
     util::{SubscriberInitExt, TryInitError},
@@ -21,6 +21,14 @@ pub fn init() {
     if DID_INIT.set(true).is_ok() {
         try_init().expect("unreachable: checked OnceLock before init");
     }
+}
+
+pub fn create_writer_and_layer() -> (impl Layer<Registry>, LineWriter) {
+    let writer = LineWriter::default();
+    let layer = tracing_subscriber::fmt::layer()
+        .json()
+        .with_writer(writer.clone());
+    (layer, writer)
 }
 
 pub fn try_init() -> Result<(), TryInitError> {


### PR DESCRIPTION
## Description

* Add TraceClient::new to create from irpc Client directly
* Expose a way to create the tracing layer with support for submitting through the trace client

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
