### PR TITLE
chore: release prep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,7 @@ iroh_v035 = ["dep:iroh_035"]
 name = "iroh-n0des"
 path = "src/main.rs"
 required-features = ["iroh_main"]
+
+[patch.crates-io]
+iroh = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }
+irpc = { git = "https://github.com/n0-computer/irpc.git", branch = "main" }

--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,19 @@
+[advisories]
+ignore = [
+    "RUSTSEC-2024-0384",
+    "RUSTSEC-2024-0436",
+    "RUSTSEC-2023-0089",
+]
+
 [bans]
+deny = [
+    "aws-lc",
+    "aws-lc-rs",
+    "aws-lc-sys",
+    "native-tls",
+    "openssl",
+]
 multiple-versions = "allow"
-deny = ["aws-lc", "aws-lc-rs", "aws-lc-sys", "native-tls", "openssl"]
 
 [licenses]
 allow = [
@@ -8,27 +21,26 @@ allow = [
     "Apache-2.0 WITH LLVM-exception",
     "BSD-2-Clause",
     "BSD-3-Clause",
-    "BSL-1.0",                        # BOSL license
-    "CDLA-Permissive-2.0",            # Community Data License Agreement Permissive 2.0 due to webpki-root-certs
+    "BSL-1.0",
+    "CDLA-Permissive-2.0",
     "ISC",
     "MIT",
     "Zlib",
-    "MPL-2.0",                        # https://fossa.com/blog/open-source-software-licenses-101-mozilla-public-license-2-0/
+    "MPL-2.0",
     "Unicode-3.0",
-    "Unlicense",                      # https://unlicense.org/
+    "Unlicense",
 ]
 
 [[licenses.clarify]]
-name = "ring"
 expression = "MIT AND ISC AND OpenSSL"
-license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+name = "ring"
 
-[advisories]
-ignore = [
-    "RUSTSEC-2024-0384", # unmaintained, no upgrade available
-    "RUSTSEC-2024-0436", # paste
-    "RUSTSEC-2023-0089", # unmainatined: postcard -> heapless -> atomic-polyfill
-]
+[[licenses.clarify.license-files]]
+hash = 3171872035
+path = "LICENSE"
 
 [sources]
-allow-git = []
+allow-git = [
+    "https://github.com/n0-computer/iroh.git",
+    "https://github.com/n0-computer/irpc.git",
+]


### PR DESCRIPTION
This PR updates the following dependencies to their latest versions:

- `iroh` from `https://github.com/n0-computer/iroh.git`
- `irpc` from `https://github.com/n0-computer/irpc.git`